### PR TITLE
#42 Removed npm's "next" tag in pre-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "tsc -w",
     "prepublishOnly": "yarn build",
     "release": "release-it",
-    "release:pre": "release-it --preRelease --npm.tag=next",
+    "release:pre": "release-it --preRelease",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
2021/1/9 の開発者会議で `npm publish` 時に `next` タグは付けず、そのまま alpha としてリリースすることになったのでコマンドから当該箇所を削除。