### PR TITLE
Fix/empty replace rules

### DIFF
--- a/src/plugins/replace.ts
+++ b/src/plugins/replace.ts
@@ -8,7 +8,7 @@ export interface ReplaceRule {
 }
 
 export function replace({ rules }: { rules?: ReplaceRule[] } = {}) {
-  if (!rules) return;
+  if (!rules || rules.length == 0) return;
   const search = rules.map(
     (rule) =>
       [

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -97,17 +97,6 @@ it('reject incorrect fences', () => {
 });
 
 it('handle fenced block', () => {
-  const result = partial(`
-:::foos
-# foo
-foovar
-:::
-`);
-
-  expect(result).toBe(
-    `<div class="foos"><section id="foo"><h1>foo</h1><p>foovar</p></section></div>`,
-  );
-
   expect(
     partial(`
 :::appendix

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -97,6 +97,17 @@ it('reject incorrect fences', () => {
 });
 
 it('handle fenced block', () => {
+  const result = partial(`
+:::foos
+# foo
+foovar
+:::
+`);
+
+  expect(result).toBe(
+    `<div class="foos"><section id="foo"><h1>foo</h1><p>foovar</p></section></div>`,
+  );
+
   expect(
     partial(`
 :::appendix
@@ -194,4 +205,21 @@ it('replace', () => {
   )
     .toBe(`<p><div class="balloon"><img src="./img/icon1.png"><span>Notice</span></div></p>
 <p><div class="balloon"><img src="./img/person.png"><span>Nod nod</span></div></p>`);
+});
+
+it('empty replace', () => {
+  const rules = [] as ReplaceRule[];
+  expect(
+    lib.stringify(
+      `
+[icon1][Notice]
+
+[person][Nod nod]`,
+      {
+        partial: true,
+        replace: rules,
+      },
+    ),
+  ).toBe(`<p>[icon1][Notice]</p>
+<p>[person][Nod nod]</p>`);
 });


### PR DESCRIPTION
replace.tsのreplace()メソッドにReplaceRuleの空配列を渡すと、利用しているhast-util-find-and-replace/index.js内でpair[0]のような形で要素があることを前提にしているため以下のエラーが発生します。

```
TypeError: Cannot read property '0' of undefined
```

空配列の場合には置換処理をスキップしてしまったほうが良いと思います。