### PR TITLE
#34 The default value of the language option is set to undefined so t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Vivliostyle Flavored Markdown (VFM), a Markdown syntax optimized for book author
     - [`style` (default: `undefined`)](#style-default-undefined)
     - [`partial` (default: `false`)](#partial-default-false)
     - [`title` (default: `undefined`)](#title-default-undefined)
-    - [`language` (default: `en`)](#language-default-en)
+    - [`language` (default: `undefined`)](#language-default-undefined)
   - [Advanced usage](#advanced-usage)
     - [Unified processor](#unified-processor)
     - [Unified plugin](#unified-plugin)
@@ -83,7 +83,7 @@ This snippet will generates:
 
 ```html
 <!DOCTYPE html>
-<html lang="en">
+<html>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -101,6 +101,8 @@ This snippet will generates:
 ### Options
 
 #### `style` (default: `undefined`)
+
+Set the specified value as the `href` attribute of `<link rel="stylesheet">`.
 
 ```js
 stringify('# Hello', { style: 'https://example.com/book.css' });
@@ -149,6 +151,8 @@ will generates:
 
 #### `partial` (default: `false`)
 
+If `true` is specified, only the HTML defined in `<body>` is output.
+
 ```js
 stringify('# Hello', { partial: true });
 ```
@@ -160,6 +164,8 @@ will generates:
 ```
 
 #### `title` (default: `undefined`)
+
+Set the specified value as the text of `<title>`.
 
 ```js
 stringify('# Hello', { title: 'Hello' });
@@ -181,7 +187,9 @@ will generates:
 </html>
 ```
 
-#### `language` (default: `en`)
+#### `language` (default: `undefined`)
+
+Set the specified value as the `lang` attribute of `<html>`.
 
 ```js
 stringify('# Hello', { language: 'ja' });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import doc from 'rehype-document';
 import rehypeStringify from 'rehype-stringify';
 import unified, { Processor } from 'unified';
+import { hast as clearHtmlLang } from './plugins/clear-html-lang';
 import { replace as handleReplace, ReplaceRule } from './plugins/replace';
 import markdown from './revive-parse';
 import html from './revive-rehype';
@@ -22,19 +23,25 @@ export function VFM({
   style = undefined,
   partial = false,
   title = undefined,
-  language = 'en',
+  language = undefined,
   replace = undefined,
 }: StringifyMarkdownOptions = {}): Processor {
   const processor = unified()
     .use(markdown)
     .data('settings', { position: false })
     .use(html);
+
   if (replace) {
     processor.use(handleReplace, { rules: replace });
   }
+
   if (!partial) {
     processor.use(doc, { language, css: style, title });
+    if (!language) {
+      processor.use(clearHtmlLang);
+    }
   }
+
   processor.use(rehypeStringify);
 
   return processor;

--- a/src/plugins/clear-html-lang.ts
+++ b/src/plugins/clear-html-lang.ts
@@ -1,0 +1,16 @@
+import { Node } from 'unist';
+import visit from 'unist-util-visit-parents';
+import { HastNode } from './hastnode';
+
+/**
+ * Clear the lang attribute of the html tag.
+ *
+ * rehype-document omits the `language` option and set `<html lang="en">`. However, the default value for this attribute is preferably unset, so if the `language` option as VFM is omitted, this function explicitly unset it.
+ */
+export const hast = () => (tree: Node) => {
+  visit<HastNode>(tree, 'element', (node) => {
+    if (node.tagName === 'html' && node.properties && node.properties.lang) {
+      node.properties.lang = undefined;
+    }
+  });
+};

--- a/src/plugins/figure.ts
+++ b/src/plugins/figure.ts
@@ -1,12 +1,8 @@
-import { Parent as HastParent } from 'hast';
 import is from 'hast-util-is-element';
 import h from 'hastscript';
 import { Node, Parent } from 'unist';
 import visit from 'unist-util-visit';
-
-interface HastNode extends HastParent {
-  properties: { [key: string]: any };
-}
+import { HastNode } from './hastnode';
 
 export const hast = () => (tree: Node) => {
   visit<HastNode>(tree, 'element', (node, index, parent) => {

--- a/src/plugins/hastnode.ts
+++ b/src/plugins/hastnode.ts
@@ -1,0 +1,13 @@
+import { Parent as HastParent } from 'hast';
+
+/**
+ * Node of HAST.
+ */
+export interface HastNode extends HastParent {
+  /** Type of Node. */
+  type: string;
+  /** Name of HTML tag. */
+  tagName: string;
+  /** Properties and attributes of HTML tag. */
+  properties: { [key: string]: any };
+}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -153,7 +153,7 @@ b</p>`);
 it('stringify markdown string into html document', () => {
   expect(lib.stringify('# こんにちは', { title: 'Custom' }))
     .toBe(`<!doctype html>
-<html lang="en">
+<html>
 <head>
 <meta charset="utf-8">
 <title>Custom</title>

--- a/tests/remark2rehype/html-lang.test.ts
+++ b/tests/remark2rehype/html-lang.test.ts
@@ -1,0 +1,34 @@
+import assert from 'assert';
+import { stringify } from '../../src/index';
+
+it('undefined', () => {
+  const actual = stringify('text');
+  const expected = `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+<p>text</p>
+</body>
+</html>
+`;
+  assert.strictEqual(actual, expected);
+});
+
+it('en', () => {
+  const actual = stringify('text', { language: 'en' });
+  const expected = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+<p>text</p>
+</body>
+</html>
+`;
+  assert.strictEqual(actual, expected);
+});


### PR DESCRIPTION
#34 As a response, if the language option is not specified, the lang attribute of the html generated by rehype-document is deleted.