### PR TITLE
fix: CLI option shorthand mistake #56

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@ const cli = meow(
  
     Options
       --style, -s    Custom stylesheet path/URL
-      --partial, -r  Output markdown fragments
+      --partial, -p  Output markdown fragments
       --title        Document title (ignored in partial mode)
       --language     Document language (ignored in partial mode)
  


### PR DESCRIPTION
CLI オプションの `--partial` におけるショートハンドは `-p` だが `--help` 表示は `-s` になっているため、修正。