### PR TITLE
chore: Add VFM options to buildProcessorTestingCode #59

### DIFF
--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,12 +1,19 @@
 import unistInspect from 'unist-util-inspect';
-import { VFM } from '../src';
+import { StringifyMarkdownOptions, VFM } from '../src';
 
 export const buildProcessorTestingCode = (
   input: string,
   expectedMdast: string,
   expectedHtml: string,
+  options: StringifyMarkdownOptions = {
+    style: undefined,
+    partial: true,
+    title: undefined,
+    language: undefined,
+    replace: undefined,
+  },
 ) => (): any => {
-  const vfm = VFM({ partial: true }).freeze();
+  const vfm = VFM(options).freeze();
   expect(unistInspect.noColor(vfm.parse(input))).toBe(expectedMdast.trim());
   expect(String(vfm.processSync(input))).toBe(expectedHtml);
 };


### PR DESCRIPTION
#50 のためにテスト時の VFM オプション変更が必要となったため buildProcessorTestingCode へ引数を追加。