### PR TITLE
#48 Generated HTML should be human readable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Vivliostyle Flavored Markdown (VFM), a Markdown syntax optimized for book author
     - [`title` (default: `undefined`)](#title-default-undefined)
     - [`language` (default: `undefined`)](#language-default-undefined)
     - [`hardLineBreaks` (default: `false`)](#hardLineBreaks-default-false)
+    - [`disableFormatHtml` (default: `false`)](#disableFormatHtml-default-false)
   - [Advanced usage](#advanced-usage)
     - [Unified processor](#unified-processor)
     - [Unified plugin](#unified-plugin)
@@ -83,7 +84,7 @@ console.log(
 This snippet will generates:
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <meta charset="utf-8" />
@@ -112,7 +113,7 @@ stringify('# Hello', { style: 'https://example.com/book.css' });
 will generates:
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <meta charset="utf-8" />
@@ -136,7 +137,7 @@ stringify('# Hello', {
 will generates:
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <meta charset="utf-8" />
@@ -175,7 +176,7 @@ stringify('# Hello', { title: 'Hello' });
 will generates:
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <meta charset="utf-8" />
@@ -199,7 +200,7 @@ stringify('# Hello', { language: 'ja' });
 will generates:
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />
@@ -228,7 +229,7 @@ line
 will generates:
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <meta charset="utf-8" />
@@ -243,6 +244,32 @@ will generates:
 </html>
 ```
 
+#### `disableFormatHtml` (default: `false`)
+
+Disable automatic HTML format. Explicitly specify true if want unformatted HTML during development or debug.
+
+```js
+stringify(
+  `text`,
+  { disableFormatHtml: true },
+);
+```
+
+will generates:
+
+```html
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+</head>
+<body>
+<p>text</p>
+</body>
+</html>
+```
+
 ### Advanced usage
 
 #### Unified processor
@@ -252,7 +279,7 @@ import { VFM } from '@vivliostyle/vfm';
 
 const processor = VFM({ partial: true });
 const html = processor.processSync('# Hello').toString();
-```
+````
 
 #### Unified plugin
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "meow": "^9.0.0",
     "refractor": "^3.3.0",
     "rehype-document": "^5.1.0",
+    "rehype-format": "^3.1.0",
     "rehype-katex": "^4.0.0",
     "rehype-raw": "^5.0.0",
     "rehype-stringify": "^8.0.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,11 +12,12 @@ const cli = meow(
       $ echo <string> | vfm
  
     Options
-      --style, -s           Custom stylesheet path/URL
-      --partial, -p         Output markdown fragments
-      --title               Document title (ignored in partial mode)
-      --language            Document language (ignored in partial mode)
-      --hard-line-breaks    Add <br> at the position of hard line breaks, without needing spaces
+      --style, -s            Custom stylesheet path/URL
+      --partial, -p          Output markdown fragments
+      --title                Document title (ignored in partial mode)
+      --language             Document language (ignored in partial mode)
+      --hard-line-breaks     Add <br> at the position of hard line breaks, without needing spaces
+      --disable-format-html  Disable automatic HTML format
  
     Examples
       $ vfm input.md
@@ -41,6 +42,9 @@ const cli = meow(
       hardLineBreaks: {
         type: 'boolean',
       },
+      disableFormatHtml: {
+        type: 'boolean',
+      },
     },
   },
 );
@@ -54,6 +58,7 @@ function compile(input: string) {
       title: cli.flags.title,
       language: cli.flags.language,
       hardLineBreaks: cli.flags.hardLineBreaks,
+      disableFormatHtml: cli.flags.disableFormatHtml,
     }),
   );
 }
@@ -65,6 +70,7 @@ function main(
     title: { type: 'string' };
     language: { type: 'string' };
     hardLineBreaks: { type: 'boolean' };
+    disableFormatHtml: { type: 'boolean' };
   }>,
 ) {
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import doc from 'rehype-document';
+import rehypeFormat from 'rehype-format';
 import rehypeStringify from 'rehype-stringify';
 import unified, { Processor } from 'unified';
 import { hast as clearHtmlLang } from './plugins/clear-html-lang';
@@ -23,6 +24,8 @@ export interface StringifyMarkdownOptions {
   replace?: ReplaceRule[];
   /** Add `<br>` at the position of hard line breaks, without needing spaces. */
   hardLineBreaks?: boolean;
+  /** Disable automatic HTML format. */
+  disableFormatHtml?: boolean;
 }
 
 export interface Hooks {
@@ -41,6 +44,7 @@ export function VFM({
   language = undefined,
   replace = undefined,
   hardLineBreaks = false,
+  disableFormatHtml = false,
 }: StringifyMarkdownOptions = {}): Processor {
   const processor = unified()
     .use(markdown({ hardLineBreaks }))
@@ -59,6 +63,11 @@ export function VFM({
   }
 
   processor.use(rehypeStringify);
+
+  // Explicitly specify true if want unformatted HTML during development or debug
+  if (!disableFormatHtml) {
+    processor.use(rehypeFormat);
+  }
 
   return processor;
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -8,7 +8,11 @@ import { ReplaceRule } from '../src/plugins/replace';
  * @returns HTML string.
  */
 function partial(body: string, hardLineBreaks = false) {
-  return lib.stringify(body, { partial: true, hardLineBreaks });
+  return lib.stringify(body, {
+    partial: true,
+    hardLineBreaks,
+    disableFormatHtml: true,
+  });
 }
 
 // Snippet
@@ -38,8 +42,9 @@ it('handle custom attributes', () => {
 });
 
 it('stringify markdown string into html document', () => {
-  expect(lib.stringify('# こんにちは', { title: 'Custom' }))
-    .toBe(`<!doctype html>
+  expect(
+    lib.stringify('# こんにちは', { title: 'Custom', disableFormatHtml: true }),
+  ).toBe(`<!doctype html>
 <html>
 <head>
 <meta charset="utf-8">
@@ -76,6 +81,7 @@ it('replace', () => {
       {
         partial: true,
         replace: rules,
+        disableFormatHtml: true,
       },
     ),
   )
@@ -94,6 +100,7 @@ it('empty replace', () => {
       {
         partial: true,
         replace: rules,
+        disableFormatHtml: true,
       },
     ),
   ).toBe(`<p>[icon1][Notice]</p>

--- a/tests/remark2rehype/html-formatter.test.ts
+++ b/tests/remark2rehype/html-formatter.test.ts
@@ -1,0 +1,43 @@
+import assert from 'assert';
+import { stringify } from '../../src/index';
+
+it('Enable (default)', () => {
+  const actual = stringify(
+    'あああああああああああああああああああああああああ いいいいいいいいいいいいいいいいいいいいいい ううううううううううううううううううううううううう えええええええええええええええええええええええええ おおおおおおおおおおおおおおおおおおおおおおお\n\nかきくけこ\n\nさしすせそ',
+  );
+  const expected = `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body>
+    <p>あああああああああああああああああああああああああ いいいいいいいいいいいいいいいいいいいいいい ううううううううううううううううううううううううう えええええええええええええええええええええええええ おおおおおおおおおおおおおおおおおおおおおおお</p>
+    <p>かきくけこ</p>
+    <p>さしすせそ</p>
+  </body>
+</html>
+`;
+  assert.strictEqual(actual, expected);
+});
+
+it('Disable', () => {
+  const actual = stringify(
+    'あああああああああああああああああああああああああ いいいいいいいいいいいいいいいいいいいいいい ううううううううううううううううううううううううう えええええええええええええええええええええええええ おおおおおおおおおおおおおおおおおおおおおおお\n\nかきくけこ\n\nさしすせそ',
+    { disableFormatHtml: true },
+  );
+  const expected = `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+<p>あああああああああああああああああああああああああ いいいいいいいいいいいいいいいいいいいいいい ううううううううううううううううううううううううう えええええええええええええええええええええええええ おおおおおおおおおおおおおおおおおおおおおおお</p>
+<p>かきくけこ</p>
+<p>さしすせそ</p>
+</body>
+</html>
+`;
+  assert.strictEqual(actual, expected);
+});

--- a/tests/remark2rehype/html-lang.test.ts
+++ b/tests/remark2rehype/html-lang.test.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import { stringify } from '../../src/index';
 
 it('undefined', () => {
-  const actual = stringify('text');
+  const actual = stringify('text', { disableFormatHtml: true });
   const expected = `<!doctype html>
 <html>
 <head>
@@ -18,7 +18,7 @@ it('undefined', () => {
 });
 
 it('en', () => {
-  const actual = stringify('text', { language: 'en' });
+  const actual = stringify('text', { language: 'en', disableFormatHtml: true });
   const expected = `<!doctype html>
 <html lang="en">
 <head>

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -19,6 +19,7 @@ export const buildProcessorTestingCode = (
     language = undefined,
     replace = undefined,
     hardLineBreaks = false,
+    disableFormatHtml = true,
   }: StringifyMarkdownOptions = {},
 ) => (): any => {
   const vfm = VFM({
@@ -28,6 +29,7 @@ export const buildProcessorTestingCode = (
     language,
     replace,
     hardLineBreaks,
+    disableFormatHtml,
   }).freeze();
   expect(unistInspect.noColor(vfm.parse(input))).toBe(expectedMdast.trim());
   expect(String(vfm.processSync(input))).toBe(expectedHtml);

--- a/types/remark.d.ts
+++ b/types/remark.d.ts
@@ -13,6 +13,7 @@ declare module 'mdast-util-to-string';
 declare module 'rehype-katex';
 declare module 'remark-slug';
 declare module 'rehype-slug';
+declare module 'rehype-format';
 declare module 'remark-breaks';
 declare module 'remark-footnotes';
 declare module 'remark-math';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3213,6 +3213,13 @@ hast-to-hyperscript@^9.0.0:
     unist-util-is "^4.0.0"
     web-namespaces "^1.0.0"
 
+hast-util-embedded@^1.0.0:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/hast-util-embedded/-/hast-util-embedded-1.0.6.tgz#ea7007323351cc43e19e1d6256b7cde66ad1aa03"
+  integrity sha512-JQMW+TJe0UAIXZMjCJ4Wf6ayDV9Yv3PBDPsHD4ExBpAspJ6MOcCX+nzVF+UJVv7OqPcg852WEMSHQPoRA+FVSw==
+  dependencies:
+    hast-util-is-element "^1.1.0"
+
 hast-util-find-and-replace@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/hast-util-find-and-replace/-/hast-util-find-and-replace-3.2.0.tgz#31596ec4656e8f00c13588ea3c5b69e5cc5ca718"
@@ -3234,6 +3241,19 @@ hast-util-from-parse5@^6.0.0:
     vfile-location "^3.2.0"
     web-namespaces "^1.0.0"
 
+hast-util-has-property@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/hast-util-has-property/-/hast-util-has-property-1.0.4.tgz#9f137565fad6082524b382c1e7d7d33ca5059f36"
+  integrity sha512-ghHup2voGfgFoHMGnaLHOjbYFACKrRh9KFttdCzMCbFoBMJXiNi2+XTrPP8+q6cDJM/RSqlCfVWrjp1H201rZg==
+
+hast-util-is-body-ok-link@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-1.0.4.tgz#49ab2fad52ef04fe70adcbc95c9fc3a6358c32be"
+  integrity sha512-mFblNpLvFbD8dG2Nw5dJBYZkxIHeph1JAh5yr4huI7T5m8cV0zaXNiqzKPX/JdjA+tIDF7c33u9cxK132KRjyQ==
+  dependencies:
+    hast-util-has-property "^1.0.0"
+    hast-util-is-element "^1.0.0"
+
 hast-util-is-element@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/hast-util-is-element/-/hast-util-is-element-1.0.4.tgz#059090a05cc02e275df1ad02caf8cb422fcd2e02"
@@ -3248,6 +3268,16 @@ hast-util-parse-selector@^2.0.0:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-2.2.4.tgz#60c99d0b519e12ab4ed32e58f150ec3f61ed1974"
   integrity sha512-gW3sxfynIvZApL4L07wryYF4+C9VvH3AUi7LAnVXV4MneGEgwOByXvFo18BgmTWnm7oHAe874jKbIB1YhHSIzA==
+
+hast-util-phrasing@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/hast-util-phrasing/-/hast-util-phrasing-1.0.5.tgz#45fb7d3efc70128b61491f9e3f080a554f138b1d"
+  integrity sha512-P3uxm+8bnwcfAS/XpGie9wMmQXAQqsYhgQQKRwmWH/V6chiq0lmTy8KjQRJmYjusdMtNKGCUksdILSZy1suSpQ==
+  dependencies:
+    hast-util-embedded "^1.0.0"
+    hast-util-has-property "^1.0.0"
+    hast-util-is-body-ok-link "^1.0.0"
+    hast-util-is-element "^1.0.0"
 
 hast-util-raw@^6.0.0:
   version "6.0.2"
@@ -3301,7 +3331,7 @@ hast-util-to-text@^2.0.0:
     repeat-string "^1.0.0"
     unist-util-find-after "^3.0.0"
 
-hast-util-whitespace@^1.0.0:
+hast-util-whitespace@^1.0.0, hast-util-whitespace@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/hast-util-whitespace/-/hast-util-whitespace-1.0.4.tgz#e4fe77c4a9ae1cb2e6c25e02df0043d0164f6e41"
   integrity sha512-I5GTdSfhYfAPNztx2xJRQpG8cuDSNt599/7YUn7Gx/WxNMsG+a835k97TDkFgk123cwjfwINaZknkKkphx/f2A==
@@ -3360,6 +3390,11 @@ html-void-elements@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-1.0.5.tgz#ce9159494e86d95e45795b166c2021c2cfca4483"
   integrity sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w==
+
+html-whitespace-sensitive-tag-names@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/html-whitespace-sensitive-tag-names/-/html-whitespace-sensitive-tag-names-1.0.3.tgz#60325c5bd331048d14ced6bac419c89d76cc9dd8"
+  integrity sha512-GX1UguduCBEAEo1hjFxc2Bz04/sDq0ACNyT7LsuoDcPfXYI3nS0NRPp3dyazLJyVUMp3GPBB56i/0Zr6CqD2PQ==
 
 htmlparser2@~3.9.2:
   version "3.9.2"
@@ -4607,12 +4642,7 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
 
-lodash@4.17.20, lodash@^4.17.13, lodash@^4.17.15:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
-
-lodash@^4.17.19, lodash@^4.17.20:
+lodash@4.17.20, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -5796,6 +5826,20 @@ rehype-document@^5.1.0:
     hastscript "^5.0.0"
     unist-builder "^2.0.0"
 
+rehype-format@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/rehype-format/-/rehype-format-3.1.0.tgz#3ed1214b4b0047cb7817e6b3471f3515caebab26"
+  integrity sha512-XC88CLU83x6ocwHbDsqbK/y+qNxqWcSp7gZdYeJzUZPQH05ABFke3Zb+H53UGsRAUTB2W95/UMMtn/pM+UFiKQ==
+  dependencies:
+    hast-util-embedded "^1.0.0"
+    hast-util-is-element "^1.0.0"
+    hast-util-phrasing "^1.0.0"
+    hast-util-whitespace "^1.0.0"
+    html-whitespace-sensitive-tag-names "^1.0.0"
+    rehype-minify-whitespace "^4.0.0"
+    repeat-string "^1.0.0"
+    unist-util-visit-parents "^3.0.0"
+
 rehype-katex@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/rehype-katex/-/rehype-katex-4.0.0.tgz#ce11a5db0bff014350e7a9cfd30147d314b14330"
@@ -5807,6 +5851,16 @@ rehype-katex@^4.0.0:
     rehype-parse "^7.0.0"
     unified "^9.0.0"
     unist-util-visit "^2.0.0"
+
+rehype-minify-whitespace@^4.0.0:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/rehype-minify-whitespace/-/rehype-minify-whitespace-4.0.5.tgz#5b4781786116216f6d5d7ceadf84e2489dd7b3cd"
+  integrity sha512-QC3Z+bZ5wbv+jGYQewpAAYhXhzuH/TVRx7z08rurBmh9AbG8Nu8oJnvs9LWj43Fd/C7UIhXoQ7Wddgt+ThWK5g==
+  dependencies:
+    hast-util-embedded "^1.0.0"
+    hast-util-is-element "^1.0.0"
+    hast-util-whitespace "^1.0.4"
+    unist-util-is "^4.0.0"
 
 rehype-parse@^7.0.0:
   version "7.0.1"


### PR DESCRIPTION
HTML を人間がよみやすく整形する機能を実装しました。Prettier ではなく `rehype-format` を利用しています。そのため長い行が自動改行されることなく維持されます。

議論の必要な点として #48 へコメントしたとおり、この PR の対応で HTML の `DOCTYPE` が README だと大文字で VFM の返すもの (`rehype-document` が付与) は小文字になっていることに気づきました。そのため PR では README に掲載した HTML を実際の出力にあわせて小文字にしてあります。