### PR TITLE
fix: fixed a crash when specifying the HTML pre tag

### DIFF
--- a/src/plugins/figure.ts
+++ b/src/plugins/figure.ts
@@ -61,8 +61,8 @@ export const hast = () => (tree: Node) => {
   visit<HastNode>(tree, 'element', (node, index, parent) => {
     // handle captioned code block
     const maybeCode = node.children?.[0] as HastNode | undefined;
-    if (is(node, 'pre') && maybeCode?.properties.title) {
-      const maybeTitle = maybeCode?.properties?.title;
+    if (is(node, 'pre') && maybeCode?.properties?.title) {
+      const maybeTitle = maybeCode.properties.title;
       delete maybeCode.properties.title;
       (parent as Parent).children[index] = h(
         'figure',

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -89,3 +89,16 @@ it('empty replace', () => {
   ).toBe(`<p>[icon1][Notice]</p>
 <p>[person][Nod nod]</p>`);
 });
+
+it('<pre>', () => {
+  const actual = lib.stringify(`<pre>\n*    *    *\n   *    *    *\n</pre>`, {
+    partial: true,
+    disableFormatHtml: true,
+  });
+  // In CommonMark parsing, a line break is inserted immediately after `<pre>`
+  // In this test, line breaks are intentionally removed according to the behavior of VFM.
+  const expected = `<pre>*    *    *
+   *    *    *
+</pre>`;
+  expect(actual).toBe(expected);
+});


### PR DESCRIPTION
#77 修正。

Markdown のコード ブロック変換と異なり `<pre>` の解析では `if` で判定している HAST の `properties.title` が存在しない。直後の処理では Optional Chaining で参照しているため、これを `if` 判定にすることで `undefined` 参照によるクラッシュを回避した。

`if` で参照が判定されるため直後の Optional Chaining は不要となる。