### PR TITLE
chor: add test to define multiple classes in frontmetter

### DIFF
--- a/docs/vfm.md
+++ b/docs/vfm.md
@@ -370,7 +370,7 @@ The priority of `title` is as follows.
 
 ```yaml
 ---
-class: twocolumn
+class: 'twocolumn'
 ---
 
 ```
@@ -379,6 +379,8 @@ class: twocolumn
 body.twocolumn {
 }
 ```
+
+To specify multiple classes, define as `class:'foo bar'`.
 
 ## Full HTML document
 

--- a/tests/block/metadata.test.ts
+++ b/tests/block/metadata.test.ts
@@ -130,3 +130,22 @@ class: 'my-class'
 `;
   assert.strictEqual(actual, expected);
 });
+
+it('multiple classes', () => {
+  const actual = stringify(
+    `---
+class: 'foo bar'
+---
+`,
+  );
+  const expected = `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body class="foo bar"></body>
+</html>
+`;
+  assert.strictEqual(actual, expected);
+});


### PR DESCRIPTION
2021/4/10 のユーザー会イベントで Frontmetter の `class` に複数の指定は可能か？という質問があったので実証テストを追加。定義された文字列をそのまま設定するだけなので通常の `class` 属性に指定する記法で OK。