### PR TITLE
chor: unified test stlyles

### DIFF
--- a/tests/html-formatter.test.ts
+++ b/tests/html-formatter.test.ts
@@ -1,8 +1,7 @@
-import assert from 'assert';
 import { stringify } from '../src/index';
 
 it('Enable (default)', () => {
-  const actual = stringify(
+  const received = stringify(
     'あああああああああああああああああああああああああ いいいいいいいいいいいいいいいいいいいいいい ううううううううううううううううううううううううう えええええええええええええええええええええええええ おおおおおおおおおおおおおおおおおおおおおおお\n\nかきくけこ\n\nさしすせそ',
   );
   const expected = `<!doctype html>
@@ -18,11 +17,11 @@ it('Enable (default)', () => {
   </body>
 </html>
 `;
-  assert.strictEqual(actual, expected);
+  expect(received).toBe(expected);
 });
 
 it('Disable', () => {
-  const actual = stringify(
+  const received = stringify(
     'あああああああああああああああああああああああああ いいいいいいいいいいいいいいいいいいいいいい ううううううううううううううううううううううううう えええええええええええええええええええええええええ おおおおおおおおおおおおおおおおおおおおおおお\n\nかきくけこ\n\nさしすせそ',
     { disableFormatHtml: true },
   );
@@ -39,5 +38,5 @@ it('Disable', () => {
 </body>
 </html>
 `;
-  assert.strictEqual(actual, expected);
+  expect(received).toBe(expected);
 });

--- a/tests/html-lang.test.ts
+++ b/tests/html-lang.test.ts
@@ -1,8 +1,7 @@
-import assert from 'assert';
 import { stringify } from '../src/index';
 
 it('undefined', () => {
-  const actual = stringify('text', { disableFormatHtml: true });
+  const received = stringify('text', { disableFormatHtml: true });
   const expected = `<!doctype html>
 <html>
 <head>
@@ -14,11 +13,14 @@ it('undefined', () => {
 </body>
 </html>
 `;
-  assert.strictEqual(actual, expected);
+  expect(received).toBe(expected);
 });
 
 it('en', () => {
-  const actual = stringify('text', { language: 'en', disableFormatHtml: true });
+  const received = stringify('text', {
+    language: 'en',
+    disableFormatHtml: true,
+  });
   const expected = `<!doctype html>
 <html lang="en">
 <head>
@@ -30,5 +32,5 @@ it('en', () => {
 </body>
 </html>
 `;
-  assert.strictEqual(actual, expected);
+  expect(received).toBe(expected);
 });

--- a/tests/metadata.test.ts
+++ b/tests/metadata.test.ts
@@ -1,8 +1,7 @@
-import assert from 'assert';
 import { stringify } from '../src/index';
 
 it('all', () => {
-  const actual = stringify(
+  const received = stringify(
     `---
 title: 'Title'
 author: 'Author'
@@ -27,11 +26,11 @@ class: 'my-class'
   </body>
 </html>
 `;
-  assert.strictEqual(actual, expected);
+  expect(received).toBe(expected);
 });
 
 it('title from heading, missing "title" property of Frontmatter', () => {
-  const actual = stringify(`# Page Title`);
+  const received = stringify(`# Page Title`);
   const expected = `<!doctype html>
 <html>
   <head>
@@ -46,11 +45,11 @@ it('title from heading, missing "title" property of Frontmatter', () => {
   </body>
 </html>
 `;
-  assert.strictEqual(actual, expected);
+  expect(received).toBe(expected);
 });
 
 it('title from options', () => {
-  const actual = stringify(
+  const received = stringify(
     `---
 author: 'Author'
 class: 'my-class'
@@ -71,11 +70,11 @@ class: 'my-class'
   <body class="my-class"></body>
 </html>
 `;
-  assert.strictEqual(actual, expected);
+  expect(received).toBe(expected);
 });
 
 it('overwrite optional title by frontmatter', () => {
-  const actual = stringify(
+  const received = stringify(
     `---
 title: 'Title'
 author: 'Author'
@@ -97,11 +96,11 @@ class: 'my-class'
   <body class="my-class"></body>
 </html>
 `;
-  assert.strictEqual(actual, expected);
+  expect(received).toBe(expected);
 });
 
 it('overwrite optional title by heading', () => {
-  const actual = stringify(
+  const received = stringify(
     `---
 author: 'Author'
 class: 'my-class'
@@ -128,11 +127,11 @@ class: 'my-class'
   </body>
 </html>
 `;
-  assert.strictEqual(actual, expected);
+  expect(received).toBe(expected);
 });
 
 it('multiple classes', () => {
-  const actual = stringify(
+  const received = stringify(
     `---
 class: 'foo bar'
 ---
@@ -147,5 +146,5 @@ class: 'foo bar'
   <body class="foo bar"></body>
 </html>
 `;
-  assert.strictEqual(actual, expected);
+  expect(received).toBe(expected);
 });


### PR DESCRIPTION
私が書いたテストで Jest の `expect` ではなく Node.js の `assert` を使っているものがあったので前者へ統一。Jest 自体は `assert` 互換である。

テスト関数が Jest 標準の `test` ではなく mocha 風な `it` (これもサポートされてる) なのでアサーションも可用性の観点から `assert` にしようと考えたが、部分的にしかそうしていなくて不統一なのと `expect` のわかりやすさもあってこちらへ統一するほうがよいと判断した。