### PR TITLE
feat: implemented math syntax with MathJax

### DIFF
--- a/docs/vfm.md
+++ b/docs/vfm.md
@@ -329,10 +329,20 @@ It also outputs the `<script>` and `<body>` attributes for processing MathJax in
   <script async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-MML-AM_CHTML"></script>
   </head>
   <body data-math-typeset>
-    <p>inline: \(x = y\)</p>
-    <p>display: $$1 + 1 = 2$$</p>
+    <p>inline: <span class="math inline">\(x = y\)</span></p>
+    <p>display: <span class="math display">$$1 + 1 = 2$$</span></p>
   </body>
 </html>
+```
+
+**CSS**
+
+```css
+.math.inline {
+}
+
+.math.display {
+}
 ```
 
 ## Frontmatter
@@ -412,8 +422,6 @@ To specify multiple classes, define as `class:'foo bar'`.
 ```
 
 ## Hard new line
-
-<Badge type="warning">PRE-RELEASE</Badge>
 
 - A newline puts `<br/>` to the end of a line.
 - Consecutive 2 newlines creates a new sentence block.

--- a/docs/vfm.md
+++ b/docs/vfm.md
@@ -307,12 +307,28 @@ It is disabled by default. It is activated by satisfying one of the following.
 - CLI options: `--math`
 - Frontmatter: `math: true` (Priority over others)
 
-**VFM**
-
 The VFM syntax for MathJax inline is `$...$` and the display is `$$...$$`.
 
+It also supports multiple lines, such as `$x = y\n1 + 1 = 2$` and `$$\nx = y\n$$`. However, if there is a blank line `\n\n` such as `$x = y\n\n1 + 1 = 2$ `, the paragraphs will be separated and it will not be a mathematical syntax.
+
+OK:
+
+- `$...$`, `$$...$$` ...Range specification matches
+- `$...\n...$`, `$\n...\n$` ...Within the same paragraph
+- `$...\$...$`, `$$...\$...$$` ...Escape `$` by `\`
+
+NG:
+
+- `$...$$`, `$$...$` ...Range specification does not match
+- `$...\n\n...$`, `$$...\n\n...$$` ...Split paragraph
+- `$ ...$` ...Space ` ` immediately after `$` at start of inline
+- `$... $` ...Space ` ` immediately before `$` at end of inline
+- `$...$5` ...Digit `0...N` immediately after `$` at end of inline
+
+**VFM**
+
 ```markdown
-inline: $x = y$
+inline:$x = y$
 
 display: $$1 + 1 = 2$$
 ```

--- a/docs/vfm.md
+++ b/docs/vfm.md
@@ -314,7 +314,7 @@ It also supports multiple lines, such as `$x = y\n1 + 1 = 2$` and `$$\nx = y\n$$
 OK:
 
 - `$...$`, `$$...$$` ...Range specification matches
-- `$...\n...$`, `$\n...\n$` ...Within the same paragraph
+- `$...\n...$`, `$$\n...\n$$` ...Within the same paragraph
 - `$...\$...$`, `$$...\$...$$` ...Escape `$` by `\`
 
 NG:

--- a/docs/vfm.md
+++ b/docs/vfm.md
@@ -344,7 +344,7 @@ It also outputs the `<script>` and `<body>` attributes for processing MathJax in
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-MML-AM_CHTML"></script>
   </head>
-  <body data-math-typeset>
+  <body data-math-typeset="true">
     <p>inline: <span class="math inline">\(x = y\)</span></p>
     <p>display: <span class="math display">$$1 + 1 = 2$$</span></p>
   </body>

--- a/docs/vfm.md
+++ b/docs/vfm.md
@@ -315,14 +315,14 @@ OK:
 
 - `$...$`, `$$...$$` ...Range specification matches
 - `$...\n...$`, `$$\n...\n$$` ...Within the same paragraph
-- `$...\$...$`, `$$...\$...$$` ...Escape `$` by `\`
+- `$...\$...$`, `$...\$...\\\$..$`,  `$$...\$...\\\$...$$` ...Escape `$` by odd `\`
 
 NG:
 
 - `$...$$`, `$$...$` ...Range specification does not match
 - `$...\n\n...$`, `$$...\n\n...$$` ...Split paragraph
-- `$ ...$` ...Space ` ` immediately after `$` at start of inline
-- `$... $` ...Space ` ` immediately before `$` at end of inline
+- `$ ...$` ...Spaces (space, tab, new line, ...etc) ` ` immediately after `$` at start of inline
+- `$... $` ...Spaces (space, tab, new line, ...etc) ` ` immediately before `$` at end of inline
 - `$...$5` ...Digit `0...N` immediately after `$` at end of inline
 
 **VFM**

--- a/docs/vfm.md
+++ b/docs/vfm.md
@@ -299,46 +299,43 @@ section.author {
 
 ## Math equation
 
-<Badge type="warning">PRE-RELEASE</Badge>
+Outputs HTML processed by [MathJax](https://www.mathjax.org/).
+
+It is disabled by default. It is activated by satisfying one of the following.
+
+- VFM options: `math: true`
+- CLI options: `--math`
+- Frontmatter: `math: true` (Priority over others)
 
 **VFM**
 
+The VFM syntax for MathJax inline is `$...$` and the display is `$$...$$`.
+
 ```markdown
-$$\sum$$
+inline: $x = y$
+
+display: $$1 + 1 = 2$$
 ```
 
 **HTML**
 
+It also outputs the `<script>` and `<body>` attributes for processing MathJax in Vivliostyle if `math` is enabled.
+
 ```html
-<p>
-  <span class="math math-inline">
-    <span class="katex">
-      <span class="katex-html" aria-hidden="true">
-        <span class="base">
-          <span class="strut" style="height:0.43056em;vertical-align:0em;">
-          </span>
-          <span class="mord mathdefault">s</span>
-          <span class="mord mathdefault">u</span>
-          <span class="mord mathdefault">m</span>
-        </span>
-      </span>
-    </span>
-  </span>
-</p>
-```
-
-**CSS**
-
-```css
-span.math {
-}
-span.math.math-inline {
-}
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <script async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-MML-AM_CHTML"></script>
+  </head>
+  <body data-math-typeset>
+    <p>inline: \(x = y\)</p>
+    <p>display: $$1 + 1 = 2$$</p>
+  </body>
+</html>
 ```
 
 ## Frontmatter
-
-<Badge type="warning">PRE-RELEASE</Badge>
 
 Frontmatter is a way of defining metadata in Markdown (file) units.
 
@@ -347,24 +344,31 @@ Frontmatter is a way of defining metadata in Markdown (file) units.
 title: 'Introduction to VFM'
 author: 'Author'
 class: 'my-class'
+math: true
 ---
 
 ```
 
 #### Reserved words
 
-| Property | Type   | Description                                                                                 |
-| -------- | ------ | ------------------------------------------------------------------------------------------- |
-| title    | String | Document title. If missing, very first heading `#` of the content will be treated as title. |
-| author   | String | Document author.                                                                            |
-| class    | String | Custom classes applied to `<body>`                                                          |
-| theme    | String | Vivliostyle theme package or bare CSS file.                                                 |
+| Property | Type    | Description                                                                                 |
+| -------- | ------- | ------------------------------------------------------------------------------------------- |
+| title    | String  | Document title. If missing, very first heading `#` of the content will be treated as title. |
+| author   | String  | Document author.                                                                            |
+| class    | String  | Custom classes applied to `<body>`                                                          |
+| math     | Boolean | Enable math syntax.                                                                         |
+| theme    | String  | Vivliostyle theme package or bare CSS file.                                                 |
 
 The priority of `title` is as follows.
 
 1. `title` property of the frontmatter
 2. First heading `#` of the content
 3. `title` option of VFM
+
+The priority of `math` is as follows.
+
+1. `math` property of the frontmatter
+2. `math` option of VFM
 
 **class**
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "release": "release-it",
     "release:pre": "release-it --preRelease --npm.tag=latest",
     "test": "jest",
-    "test:debug": "jest tests/xxx.test.ts --silent=false --verbose false"
+    "test:debug": "jest tests/math.test.ts --silent=false --verbose false"
   },
   "dependencies": {
     "debug": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "release": "release-it",
     "release:pre": "release-it --preRelease --npm.tag=latest",
     "test": "jest",
-    "test:debug": "jest tests/xxx.test.ts --silent=false --verbose false"
+    "test:debug": "jest tests/math.test.ts --silent=false --verbose false"
   },
   "dependencies": {
     "debug": "^4.3.1",
@@ -59,6 +59,7 @@
     "hast-util-is-element": "^1.1.0",
     "hastscript": "^6.0.0",
     "js-yaml": "^4.0.0",
+    "mdast-util-find-and-replace": "^1.1.1",
     "mdast-util-to-hast": "^10.1.1",
     "mdast-util-to-string": "^2.0.0",
     "meow": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "release": "release-it",
     "release:pre": "release-it --preRelease --npm.tag=latest",
     "test": "jest",
-    "test:debug": "jest tests/math.test.ts --silent=false --verbose false"
+    "test:debug": "jest tests/xxx.test.ts --silent=false --verbose false"
   },
   "dependencies": {
     "debug": "^4.3.1",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ const cli = meow(
       --language             Document language (ignored in partial mode)
       --hard-line-breaks     Add <br> at the position of hard line breaks, without needing spaces
       --disable-format-html  Disable automatic HTML format
+      --math                 Enable math syntax
  
     Examples
       $ vfm input.md
@@ -45,6 +46,9 @@ const cli = meow(
       disableFormatHtml: {
         type: 'boolean',
       },
+      math: {
+        type: 'boolean',
+      },
     },
   },
 );
@@ -59,6 +63,7 @@ function compile(input: string) {
       language: cli.flags.language,
       hardLineBreaks: cli.flags.hardLineBreaks,
       disableFormatHtml: cli.flags.disableFormatHtml,
+      math: cli.flags.math,
     }),
   );
 }
@@ -71,6 +76,7 @@ function main(
     language: { type: 'string' };
     hardLineBreaks: { type: 'boolean' };
     disableFormatHtml: { type: 'boolean' };
+    math: { type: 'boolean' };
   }>,
 ) {
   try {

--- a/src/plugins/math.ts
+++ b/src/plugins/math.ts
@@ -11,7 +11,7 @@ import visit from 'unist-util-visit';
  * - OK: `$x = y$`, `$x = \$y$`
  * - NG: `$$x = y$`, `$x = y$$`, `$ x = y$`, `$x = y $`, `$x = y$7`
  */
-const regexpInline = /\$([^$\s].*?[^\\$\s])\$(?!(\$|\d))/gs;
+const regexpInline = /\$([^$\s].*?(?<=[^\\$\s]|[^\\](?:\\\\)+))\$(?!\$|\d)/gs;
 
 /** Display math format, e.g. `$$...$$`. */
 const regexpDisplay = /\$\$([^$].*?[^$])\$\$(?!\$)/gs;

--- a/src/plugins/math.ts
+++ b/src/plugins/math.ts
@@ -14,7 +14,7 @@ import visit from 'unist-util-visit';
 const regexpInline = /\$([^$\s].*?(?<=[^\\$\s]|[^\\](?:\\\\)+))\$(?!\$|\d)/gs;
 
 /** Display math format, e.g. `$$...$$`. */
-const regexpDisplay = /\$\$([^$].*?[^$])\$\$(?!\$)/gs;
+const regexpDisplay = /\$\$([^$].*?(?<=[^$]))\$\$(?!\$)/gs;
 
 /** Type of inline math in Markdown AST. */
 const typeInline = 'inlineMath';

--- a/src/plugins/math.ts
+++ b/src/plugins/math.ts
@@ -11,7 +11,7 @@ import visit from 'unist-util-visit';
  * - OK: `$x = y$`, `$x = \$y$`
  * - NG: `$$x = y$`, `$x = y$$`, `$ x = y$`, `$x = y $`, `$x = y$7`
  */
-const regexpInline = /\$([^($| )].*?[^(\\|$| )])\$(?!(\$|\d))/gs;
+const regexpInline = /\$([^$\s].*?[^\\$\s])\$(?!(\$|\d))/gs;
 
 /** Display math format, e.g. `$$...$$`. */
 const regexpDisplay = /\$\$([^$].*?[^$])\$\$(?!\$)/gs;

--- a/src/plugins/math.ts
+++ b/src/plugins/math.ts
@@ -1,13 +1,185 @@
-import is from 'hast-util-is-element';
-import katex from 'rehype-katex';
+import { Element } from 'hast';
+import findReplace from 'mdast-util-find-and-replace';
+import { Handler } from 'mdast-util-to-hast';
+import { Plugin, Transformer } from 'unified';
 import { Node } from 'unist';
-import remove from 'unist-util-remove';
+import u from 'unist-builder';
+import visit from 'unist-util-visit';
 
-const removeMathML = () => (tree: Node) => {
-  remove(tree, (node: any) => {
-    const isKatexMathML = node.properties?.className?.includes('katex-mathml');
-    return is(node, 'span') && isKatexMathML;
-  });
+/** Inline math format, e.g. `$...$`. */
+const regexpInline = /\$([^$].*?[^$])\$(?!\$)/g;
+
+/** Display math format, e.g. `$$...$$`. */
+const regexpDisplay = /\$\$([^$].*?[^$])\$\$(?!\$)/g;
+
+/** Type of inline math in Markdown AST. */
+const typeInline = 'inlineMath';
+
+/** Type of display math in Markdown AST. */
+const typeDisplay = 'displayMath';
+
+/** URL of MathJax v2 supported by Vivliostyle. */
+const mathUrl =
+  'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-MML-AM_CHTML';
+
+const createTokenizer = () => {
+  const tokenizerInlineMath: Tokenizer = function (eat, value, silent) {
+    if (!value.startsWith('$') || value.startsWith('$$')) {
+      return;
+    }
+
+    const match = new RegExp(regexpInline).exec(value);
+    if (!match) {
+      return;
+    }
+
+    if (silent) {
+      return true;
+    }
+
+    const [eaten, valueText] = match;
+    const now = eat.now();
+    now.column += 1;
+    now.offset += 1;
+
+    return eat(eaten)({
+      type: typeInline,
+      children: [],
+      data: { hName: typeInline, value: valueText },
+    });
+  };
+
+  tokenizerInlineMath.notInLink = true;
+  tokenizerInlineMath.locator = function (value: string, fromIndex: number) {
+    return value.indexOf('$', fromIndex);
+  };
+
+  const tokenizerDisplayMath: Tokenizer = function (eat, value, silent) {
+    if (!value.startsWith('$$') || value.startsWith('$$$')) {
+      return;
+    }
+
+    const match = new RegExp(regexpDisplay).exec(value);
+    if (!match) {
+      return;
+    }
+
+    if (silent) {
+      return true;
+    }
+
+    const [eaten, valueText] = match;
+    const now = eat.now();
+    now.column += 1;
+    now.offset += 1;
+
+    return eat(eaten)({
+      type: typeDisplay,
+      children: [],
+      data: { hName: typeDisplay, value: valueText },
+    });
+  };
+
+  tokenizerDisplayMath.notInLink = true;
+  tokenizerDisplayMath.locator = function (value: string, fromIndex: number) {
+    return value.indexOf('$$', fromIndex);
+  };
+
+  return { tokenizerInlineMath, tokenizerDisplayMath };
 };
 
-export const hast = { plugins: [katex, removeMathML] };
+/**
+ * Process Markdown AST.
+ * @returns Transformer or undefined (less than remark 13).
+ */
+export const mdast: Plugin = function (): Transformer | undefined {
+  // For less than remark 13 with exclusive other markdown syntax
+  if (
+    this.Parser &&
+    this.Parser.prototype.inlineTokenizers &&
+    this.Parser.prototype.inlineMethods
+  ) {
+    const { inlineTokenizers, inlineMethods } = this.Parser.prototype;
+    const tokenizers = createTokenizer();
+    inlineTokenizers[typeInline] = tokenizers.tokenizerInlineMath;
+    inlineTokenizers[typeDisplay] = tokenizers.tokenizerDisplayMath;
+    inlineMethods.splice(inlineMethods.indexOf('text'), 0, typeInline);
+    inlineMethods.splice(inlineMethods.indexOf('text'), 0, typeDisplay);
+    return;
+  }
+
+  return (tree: Node) => {
+    findReplace(tree, regexpInline, (_: string, valueText: string) => {
+      return {
+        type: typeInline,
+        data: {
+          hName: typeInline,
+          value: valueText,
+        },
+        children: [],
+      };
+    });
+
+    findReplace(tree, regexpDisplay, (_: string, valueText: string) => {
+      return {
+        type: typeDisplay,
+        data: {
+          hName: typeDisplay,
+          value: valueText,
+        },
+        children: [],
+      };
+    });
+  };
+};
+
+/**
+ * Handle inline math to Hypertext AST.
+ * @param h Hypertext AST formatter.
+ * @param node Node.
+ * @returns Hypertext AST.
+ */
+export const handlerInlineMath: Handler = (h, node: Node) => {
+  if (!node.data) node.data = {};
+
+  return u('text', `\\(${node.data.value as string}\\)`);
+};
+
+/**
+ * Handle display math to Hypertext AST.
+ * @param h Hypertext AST formatter.
+ * @param node Node.
+ * @returns Hypertext AST.
+ */
+export const handlerDisplayMath: Handler = (h, node: Node) => {
+  if (!node.data) node.data = {};
+
+  return u('text', `$$${node.data.value as string}$$`);
+};
+
+/**
+ * Process math related Hypertext AST.
+ * Set the `<script>` to load MathJax and `<body>` attribute that enable math typesetting.
+ */
+export const hast = () => (tree: Node) => {
+  visit<Element>(tree, 'element', (node) => {
+    switch (node.tagName) {
+      case 'head':
+        node.children.push({
+          type: 'element',
+          tagName: 'script',
+          properties: {
+            async: true,
+            src: mathUrl,
+          },
+          children: [],
+        });
+        node.children.push({ type: 'text', value: '\n' });
+        break;
+
+      case 'body':
+        node.properties = { ...node.properties, 'data-math-typeset': true };
+        break;
+    }
+  });
+};

--- a/src/plugins/math.ts
+++ b/src/plugins/math.ts
@@ -22,7 +22,11 @@ const typeDisplay = 'displayMath';
 const mathUrl =
   'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-MML-AM_CHTML';
 
-const createTokenizer = () => {
+/**
+ * Create tokenizers for remark-parse.
+ * @returns Tokenizers.
+ */
+const createTokenizers = () => {
   const tokenizerInlineMath: Tokenizer = function (eat, value, silent) {
     if (!value.startsWith('$') || value.startsWith('$$')) {
       return;
@@ -100,7 +104,7 @@ export const mdast: Plugin = function (): Transformer | undefined {
     this.Parser.prototype.inlineMethods
   ) {
     const { inlineTokenizers, inlineMethods } = this.Parser.prototype;
-    const tokenizers = createTokenizer();
+    const tokenizers = createTokenizers();
     inlineTokenizers[typeInline] = tokenizers.tokenizerInlineMath;
     inlineTokenizers[typeDisplay] = tokenizers.tokenizerDisplayMath;
     inlineMethods.splice(inlineMethods.indexOf('text'), 0, typeInline);
@@ -140,9 +144,20 @@ export const mdast: Plugin = function (): Transformer | undefined {
  * @returns Hypertext AST.
  */
 export const handlerInlineMath: Handler = (h, node: Node) => {
-  if (!node.data) node.data = {};
+  if (!node.data) {
+    node.data = {};
+  }
 
-  return u('text', `\\(${node.data.value as string}\\)`);
+  return h(
+    {
+      type: 'element',
+    },
+    'span',
+    {
+      class: 'math inline',
+    },
+    [u('text', `\\(${node.data.value as string}\\)`)],
+  );
 };
 
 /**
@@ -154,7 +169,16 @@ export const handlerInlineMath: Handler = (h, node: Node) => {
 export const handlerDisplayMath: Handler = (h, node: Node) => {
   if (!node.data) node.data = {};
 
-  return u('text', `$$${node.data.value as string}$$`);
+  return h(
+    {
+      type: 'element',
+    },
+    'span',
+    {
+      class: 'math display',
+    },
+    [u('text', `$$${node.data.value as string}$$`)],
+  );
 };
 
 /**

--- a/src/plugins/math.ts
+++ b/src/plugins/math.ts
@@ -6,11 +6,15 @@ import { Node } from 'unist';
 import u from 'unist-builder';
 import visit from 'unist-util-visit';
 
-/** Inline math format, e.g. `$...$`. */
-const regexpInline = /\$([^$].*?[^$])\$(?!\$)/g;
+/**
+ * Inline math format, e.g. `$...$`.
+ * - OK: `$x = y$`, `$x = \$y$`
+ * - NG: `$$x = y$`, `$x = y$$`, `$ x = y$`, `$x = y $`, `$x = y$7`
+ */
+const regexpInline = /\$([^($| )].*?[^(\\|$| )])\$(?!(\$|\d))/gs;
 
 /** Display math format, e.g. `$$...$$`. */
-const regexpDisplay = /\$\$([^$].*?[^$])\$\$(?!\$)/g;
+const regexpDisplay = /\$\$([^$].*?[^$])\$\$(?!\$)/gs;
 
 /** Type of inline math in Markdown AST. */
 const typeInline = 'inlineMath';
@@ -28,7 +32,11 @@ const mathUrl =
  */
 const createTokenizers = () => {
   const tokenizerInlineMath: Tokenizer = function (eat, value, silent) {
-    if (!value.startsWith('$') || value.startsWith('$$')) {
+    if (
+      !value.startsWith('$') ||
+      value.startsWith('$ ') ||
+      value.startsWith('$$')
+    ) {
       return;
     }
 

--- a/src/plugins/math.ts
+++ b/src/plugins/math.ts
@@ -178,7 +178,7 @@ export const hast = () => (tree: Node) => {
         break;
 
       case 'body':
-        node.properties = { ...node.properties, 'data-math-typeset': true };
+        node.properties = { ...node.properties, 'data-math-typeset': 'true' };
         break;
     }
   });

--- a/src/plugins/metadata.ts
+++ b/src/plugins/metadata.ts
@@ -8,19 +8,26 @@ import visit from 'unist-util-visit';
 import { VFile } from 'vfile';
 
 /**
+ * Metadata from frontmatter in markdown.
+ */
+export type Metadata = {
+  /** Title. */
+  title?: string;
+  /** Author. */
+  author?: string;
+  /** Value to specify for the `class` attribute of `<body>`. */
+  class?: string;
+  /** Enable math syntax. */
+  math?: boolean;
+  /** Value that indicates that the document is TOC. */
+  toc?: boolean;
+};
+
+/**
  * Extension of VFM metadata to VFile data.
  */
-interface MetadataVFile extends VFile {
-  data: {
-    /** Title. */
-    title?: string;
-    /** Author. */
-    author?: string;
-    /** Value to specify for the `class` attribute of `<body>`. */
-    class?: string;
-    /** Value that indicates that the document is TOC. */
-    toc?: boolean;
-  };
+export interface MetadataVFile extends VFile {
+  data: Metadata;
 }
 
 /**
@@ -39,6 +46,7 @@ const setAuthor = (node: Element, author: string) => {
 
 /**
  * Set the title to `<head>`.
+ * If `<title>` already exists, rewrite its text. Otherwise, add a new one at the end of `<head>`.
  * @param node Node of HAST.
  * @param title Title.
  */
@@ -48,6 +56,7 @@ const setTitle = (node: Element, title: string) => {
   ) as Element | undefined;
 
   if (titleElement) {
+    // Overwrite what was set in `rehype-document`
     const text = titleElement.children.find((n) => n.type === 'text');
     if (text) {
       text.value = title;

--- a/src/revive-parse.ts
+++ b/src/revive-parse.ts
@@ -1,12 +1,12 @@
 import breaks from 'remark-breaks';
 import footnotes from 'remark-footnotes';
 import frontmatter from 'remark-frontmatter';
-import math from 'remark-math';
 import markdown from 'remark-parse';
 import slug from 'remark-slug';
 import unified from 'unified';
 import { mdast as attr } from './plugins/attr';
 import { mdast as code } from './plugins/code';
+import { mdast as math } from './plugins/math';
 import { mdast as metadata } from './plugins/metadata';
 import { mdast as ruby } from './plugins/ruby';
 import { mdast as section } from './plugins/section';
@@ -14,26 +14,20 @@ import { mdast as toc } from './plugins/toc';
 import { inspect } from './utils';
 
 /**
- * Options for Markdown conversion.
- */
-export interface MarkdownOptions {
-  /** Add `<br>` at the position of hard line breaks, without needing spaces. */
-  hardLineBreaks: boolean;
-}
-
-/**
- * Create MDAST parsers.
- * @param options Options.
+ * Create Markdown AST parsers.
+ * @param hardLineBreaks Add `<br>` at the position of hard line breaks, without needing spaces..
+ * @param enableMath Enable math syntax.
  * @returns Parsers.
  */
 export const reviveParse = (
-  options: MarkdownOptions,
+  hardLineBreaks: boolean,
+  enableMath: boolean,
 ): unified.PluggableList<unified.Settings> => [
   [markdown, { gfm: true, commonmark: true }],
+  ...(hardLineBreaks ? [breaks] : []),
+  ...(enableMath ? [math] : []),
   ruby,
-  ...(options.hardLineBreaks ? [breaks] : []),
   [footnotes, { inlineNotes: true }],
-  math,
   attr,
   slug,
   section,

--- a/src/revive-rehype.ts
+++ b/src/revive-rehype.ts
@@ -3,16 +3,26 @@ import remark2rehype from 'remark-rehype';
 import unified from 'unified';
 import { handler as code } from './plugins/code';
 import { hast as figure } from './plugins/figure';
-import { hast as math } from './plugins/math';
+import {
+  handlerDisplayMath as displayMath,
+  handlerInlineMath as inlineMath,
+} from './plugins/math';
 import { handler as ruby } from './plugins/ruby';
 import { inspect } from './utils';
 
-export default [
+/**
+ * Create Hypertext AST handlers and transformers.
+ * @param enableMath Enable math syntax.
+ * @returns Handlers and transformers.
+ */
+export const reviveRehype = [
   [
     remark2rehype,
     {
       allowDangerousHtml: true,
       handlers: {
+        displayMath,
+        inlineMath,
         ruby,
         code,
       },
@@ -20,6 +30,5 @@ export default [
   ],
   raw,
   figure,
-  math,
   inspect('hast'),
 ] as unified.PluggableList<unified.Settings>;

--- a/tests/defs.test.ts
+++ b/tests/defs.test.ts
@@ -1,7 +1,7 @@
 import { VFM } from '../src';
 
 it('has valid inlineMethods', () => {
-  const vfm = VFM({ partial: true }).freeze();
+  const vfm = VFM({ partial: true, math: true }).freeze();
   expect(vfm.Parser.prototype.inlineMethods).toEqual([
     'escape',
     'autoLink',
@@ -17,20 +17,20 @@ it('has valid inlineMethods', () => {
     'deletion',
     'code',
     'break',
+    'inlineMath',
+    'displayMath',
     'ruby',
-    'math',
     'text',
   ]);
 });
 
 it('has valid blockMethods', () => {
-  const vfm = VFM({ partial: true }).freeze();
+  const vfm = VFM({ partial: true, math: true }).freeze();
   expect(vfm.Parser.prototype.blockMethods).toEqual([
     'yamlFrontMatter',
     'blankLine',
     'indentedCode',
     'fencedCode',
-    'math',
     'blockquote',
     'atxHeading',
     'thematicBreak',
@@ -46,12 +46,11 @@ it('has valid blockMethods', () => {
 });
 
 it('has valid interruptParagraph', () => {
-  const vfm = VFM({ partial: true }).freeze();
+  const vfm = VFM({ partial: true, math: true }).freeze();
   const interrupters = vfm.Parser.prototype.interruptParagraph.map(
     ([name]: string[]) => name,
   );
   expect(interrupters).toEqual([
-    'math',
     'thematicBreak',
     'list',
     'atxHeading',
@@ -64,12 +63,11 @@ it('has valid interruptParagraph', () => {
 });
 
 it('has valid interruptList', () => {
-  const vfm = VFM({ partial: true }).freeze();
+  const vfm = VFM({ partial: true, math: true }).freeze();
   const interrupters = vfm.Parser.prototype.interruptList.map(
     ([name]: string[]) => name,
   );
   expect(interrupters).toEqual([
-    'math',
     'atxHeading',
     'fencedCode',
     'thematicBreak',
@@ -78,12 +76,11 @@ it('has valid interruptList', () => {
 });
 
 it('has valid interruptBlockquote', () => {
-  const vfm = VFM({ partial: true }).freeze();
+  const vfm = VFM({ partial: true, math: true }).freeze();
   const interrupters = vfm.Parser.prototype.interruptBlockquote.map(
     ([name]: string[]) => name,
   );
   expect(interrupters).toEqual([
-    'math',
     'indentedCode',
     'fencedCode',
     'atxHeading',
@@ -96,7 +93,7 @@ it('has valid interruptBlockquote', () => {
 });
 
 it('has valid interruptFootnoteDefinition', () => {
-  const vfm = VFM({ partial: true }).freeze();
+  const vfm = VFM({ partial: true, math: true }).freeze();
   const interrupters = vfm.Parser.prototype.interruptFootnoteDefinition.map(
     ([name]: string[]) => name,
   );

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -31,8 +31,8 @@ it('stringify markdown string into html document', () => {
 <html>
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>こんにちは</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
 <section id="こんにちは"><h1>こんにちは</h1></section>

--- a/tests/math.test.ts
+++ b/tests/math.test.ts
@@ -7,33 +7,50 @@ const options = {
 };
 
 it('inline', () => {
-  const received = stringify('text$x=y$text', options);
-  const expected = '<p>text<span class="math inline">\\(x=y\\)</span>text</p>';
+  const md = `text$x = y$text
+$(x = y)$
+$|x = y|$`;
+  const received = stringify(md, options);
+  const expected = `<p>text<span class="math inline">\\(x = y\\)</span>text
+<span class="math inline">\\((x = y)\\)</span>
+<span class="math inline">\\(|x = y|\\)</span></p>`;
   expect(received).toBe(expected);
 });
 
 it('inline: multiline', () => {
-  const md = `$x=y
+  const md = `$x = y
 1 + 1 = 2$`;
   const received = stringify(md, options);
-  const expected = `<p><span class="math inline">\\(x=y
+  const expected = `<p><span class="math inline">\\(x = y
 1 + 1 = 2\\)</span></p>`;
   expect(received).toBe(expected);
 });
 
-it('inline: ignore "$ ...$"', () => {
-  const md = 'text $ text$x = y$';
+it('inline: ignore "$ ...$", "$\n...$", "$\t...$"', () => {
+  const md = `text $ text$x = y$
+$
+x = y$
+$\tx = y$
+`;
   const received = stringify(md, options);
-  const expected =
-    '<p>text $ text<span class="math inline">\\(x = y\\)</span></p>';
+  const expected = `<p>text $ text<span class="math inline">\\(x = y\\)</span>
+$
+x = y$
+$\tx = y$</p>`;
   expect(received).toBe(expected);
 });
 
 it('inline: ignore "$... $"', () => {
-  const md = 'text $x = $y$ text';
+  const md = `text $x = $y$ text
+$x = y
+$
+$x = y\t$
+`;
   const received = stringify(md, options);
-  const expected =
-    '<p>text <span class="math inline">\\(x = $y\\)</span> text</p>';
+  const expected = `<p>text <span class="math inline">\\(x = $y\\)</span> text
+$x = y
+$
+$x = y\t$</p>`;
   expect(received).toBe(expected);
 });
 

--- a/tests/math.test.ts
+++ b/tests/math.test.ts
@@ -1,142 +1,84 @@
-import { stripIndent } from 'common-tags';
-import { buildProcessorTestingCode } from './utils';
+import { stringify } from '../src/index';
 
-it(
-  'simple math block',
-  buildProcessorTestingCode(
-    stripIndent`
-    $$
-    v^2
-    $$
-    `,
-    stripIndent`
-    root[1]
-    └─0 math "v^2"
-          data: {"hName":"div","hProperties":{"className":["math","math-display"]},"hChildren":[{"type":"text","value":"v^2"}]}
-    `,
-    `<div class="math math-display"><span class="katex-display"><span class="katex"><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.8641079999999999em;vertical-align:0em;"></span><span class="mord"><span class="mord mathnormal" style="margin-right:0.03588em;">v</span><span class="msupsub"><span class="vlist-t"><span class="vlist-r"><span class="vlist" style="height:0.8641079999999999em;"><span style="top:-3.113em;margin-right:0.05em;"><span class="pstrut" style="height:2.7em;"></span><span class="sizing reset-size6 size3 mtight"><span class="mord mtight">2</span></span></span></span></span></span></span></span></span></span></span></span></div>`,
-  ),
-);
+const options = {
+  partial: true,
+  disableFormatHtml: true,
+  math: true,
+};
 
-it(
-  'paired dollar',
-  buildProcessorTestingCode(
-    stripIndent`
-    $$$
-    $
-    $$
-    $$$
-    `,
-    stripIndent`
-    root[1]
-    └─0 math "$\\n$$"
-          data: {"hName":"div","hProperties":{"className":["math","math-display"]},"hChildren":[{"type":"text","value":"$\\n$$"}]}
-    `,
-    `<div class="math math-display"><span class="katex-error" title="ParseError: KaTeX parse error: Can&#x27;t use function &#x27;$&#x27; in math mode at position 1: $̲ $$" style="color:#cc0000">$ $$</span></div>`,
-  ),
-);
+it('inline', () => {
+  const received = stringify('text$x=y$text', options);
+  const expected = '<p>text\\(x=y\\)text</p>';
+  expect(received).toBe(expected);
+});
 
-it(
-  'skip any block rules inside math',
-  buildProcessorTestingCode(
-    stripIndent`
-    $$
+it('display', () => {
+  const received = stringify('text$$1 + 1 = 2$$text', options);
+  const expected = '<p>text$$1 + 1 = 2$$text</p>';
+  expect(received).toBe(expected);
+});
 
-    <div></div>
-    $$
-    `,
-    stripIndent`
-    root[1]
-    └─0 math "\\n<div></div>"
-          data: {"hName":"div","hProperties":{"className":["math","math-display"]},"hChildren":[{"type":"text","value":"\\n<div></div>"}]}
-    `,
-    `<div class="math math-display"><span class="katex-display"><span class="katex"><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.5782em;vertical-align:-0.0391em;"></span><span class="mrel">&#x3C;</span><span class="mspace" style="margin-right:0.2777777777777778em;"></span></span><span class="base"><span class="strut" style="height:0.73354em;vertical-align:-0.0391em;"></span><span class="mord mathnormal">d</span><span class="mord mathnormal">i</span><span class="mord mathnormal" style="margin-right:0.03588em;">v</span><span class="mspace" style="margin-right:0.2777777777777778em;"></span><span class="mrel">></span></span><span class="base"><span class="strut" style="height:0.5782em;vertical-align:-0.0391em;"></span><span class="mrel">&#x3C;</span><span class="mspace" style="margin-right:0.2777777777777778em;"></span></span><span class="base"><span class="strut" style="height:1em;vertical-align:-0.25em;"></span><span class="mord">/</span><span class="mord mathnormal">d</span><span class="mord mathnormal">i</span><span class="mord mathnormal" style="margin-right:0.03588em;">v</span><span class="mspace" style="margin-right:0.2777777777777778em;"></span><span class="mrel">></span></span></span></span></span></div>`,
-  ),
-);
-
-describe('inline', () => {
-  it(
-    'simple inlineMath',
-    buildProcessorTestingCode(
-      `$x$`,
-      stripIndent`
-      root[1]
-      └─0 paragraph[1]
-          └─0 inlineMath "x"
-                data: {"hName":"span","hProperties":{"className":["math","math-inline"]},"hChildren":[{"type":"text","value":"x"}]}
-      `,
-      `<p><span class="math math-inline"><span class="katex"><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.43056em;vertical-align:0em;"></span><span class="mord mathnormal">x</span></span></span></span></span></p>`,
-    ),
+it('inline and display', () => {
+  const received = stringify(
+    'inline: $x = y$\n\ndisplay: $$1 + 1 = 2$$',
+    options,
   );
+  const expected = '<p>inline: \\(x = y\\)</p>\n<p>display: $$1 + 1 = 2$$</p>';
+  expect(received).toBe(expected);
+});
 
-  it(
-    "isn't greedy",
-    buildProcessorTestingCode(
-      `$x$y$`,
-      stripIndent`
-      root[1]
-      └─0 paragraph[2]
-          ├─0 inlineMath "x"
-          │     data: {"hName":"span","hProperties":{"className":["math","math-inline"]},"hChildren":[{"type":"text","value":"x"}]}
-          └─1 text "y$"
-      `,
-      `<p><span class="math math-inline"><span class="katex"><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.43056em;vertical-align:0em;"></span><span class="mord mathnormal">x</span></span></span></span></span>y$</p>`,
-    ),
-  );
+it('un-match', () => {
+  const received = stringify('text$$$unmatch$$$text', options);
+  const expected = '<p>text$$$unmatch$$$text</p>';
+  expect(received).toBe(expected);
+});
 
-  it(
-    'double dollar',
-    buildProcessorTestingCode(
-      `$$x$$`,
-      stripIndent`
-      root[1]
-      └─0 paragraph[1]
-          └─0 inlineMath "x"
-                data: {"hName":"span","hProperties":{"className":["math","math-inline"]},"hChildren":[{"type":"text","value":"x"}]}
-      `,
-      `<p><span class="math math-inline"><span class="katex"><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.43056em;vertical-align:0em;"></span><span class="mord mathnormal">x</span></span></span></span></span></p>`,
-    ),
-  );
+it('inline: exclusive other markdown syntax', () => {
+  const received = stringify('text$**bold**$text', options);
+  const expected = '<p>text\\(**bold**\\)text</p>';
+  expect(received).toBe(expected);
+});
 
-  it(
-    'empty math',
-    buildProcessorTestingCode(
-      `$$`,
-      stripIndent`
-      root[1]
-      └─0 paragraph[1]
-          └─0 text "$$"
-      `,
-      `<p>$$</p>`,
-    ),
-  );
+it('display: exclusive other markdown syntax', () => {
+  const received = stringify('text$$**bold**$$text', options);
+  const expected = '<p>text$$**bold**$$text</p>';
+  expect(received).toBe(expected);
+});
 
-  it(
-    'nested math',
-    buildProcessorTestingCode(
-      `$$a$b$$c$`,
-      stripIndent`
-      root[1]
-      └─0 paragraph[2]
-          ├─0 inlineMath "a$b"
-          │     data: {"hName":"span","hProperties":{"className":["math","math-inline"]},"hChildren":[{"type":"text","value":"a$b"}]}
-          └─1 text "c$"
-      `,
-      `<p><span class="math math-inline"><span class="katex-error" title="ParseError: KaTeX parse error: Can&#x27;t use function &#x27;$&#x27; in math mode at position 2: a$̲b" style="color:#cc0000">a$b</span></span>c$</p>`,
-    ),
-  );
+it('HTML header and body', () => {
+  const received = stringify('$x=y$', { math: true, disableFormatHtml: true });
+  const expected = `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-MML-AM_CHTML"></script>
+</head>
+<body data-math-typeset>
+<p>\\(x=y\\)</p>
+</body>
+</html>
+`;
+  expect(received).toBe(expected);
+});
 
-  it(
-    'math with newline',
-    buildProcessorTestingCode(
-      `$x\ny$`,
-      stripIndent`
-      root[1]
-      └─0 paragraph[1]
-          └─0 inlineMath "x\\ny"
-                data: {"hName":"span","hProperties":{"className":["math","math-inline"]},"hChildren":[{"type":"text","value":"x\\ny"}]}
-      `,
-      `<p><span class="math math-inline"><span class="katex"><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.625em;vertical-align:-0.19444em;"></span><span class="mord mathnormal">x</span><span class="mord mathnormal" style="margin-right:0.03588em;">y</span></span></span></span></span></p>`,
-    ),
-  );
+it('disable', () => {
+  const markdown = `---
+math: false
+---
+$x=y$
+`;
+  const received = stringify(markdown, { math: true, disableFormatHtml: true });
+  const expected = `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+<p>$x=y$</p>
+</body>
+</html>
+`;
+  expect(received).toBe(expected);
 });

--- a/tests/math.test.ts
+++ b/tests/math.test.ts
@@ -54,7 +54,7 @@ it('HTML header and body', () => {
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <script async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-MML-AM_CHTML"></script>
 </head>
-<body data-math-typeset>
+<body data-math-typeset="true">
 <p>\\(x=y\\)</p>
 </body>
 </html>

--- a/tests/math.test.ts
+++ b/tests/math.test.ts
@@ -8,10 +8,12 @@ const options = {
 
 it('inline', () => {
   const md = `text$x = y$text
+$a$
 $(x = y)$
 $|x = y|$`;
   const received = stringify(md, options);
   const expected = `<p>text<span class="math inline">\\(x = y\\)</span>text
+<span class="math inline">\\(a\\)</span>
 <span class="math inline">\\((x = y)\\)</span>
 <span class="math inline">\\(|x = y|\\)</span></p>`;
   expect(received).toBe(expected);
@@ -62,10 +64,10 @@ it('inline: ignore "$" with number', () => {
 });
 
 it('inline: ignore "$.\\$.$"', () => {
-  const md = 'text $x = 5\\$ + 4$ text';
+  const md = 'text $x = 5\\$ + \\\\\\$ + 4$ text';
   const received = stringify(md, options);
   const expected =
-    '<p>text <span class="math inline">\\(x = 5\\$ + 4\\)</span> text</p>';
+    '<p>text <span class="math inline">\\(x = 5\\$ + \\\\\\$ + 4\\)</span> text</p>';
   expect(received).toBe(expected);
 });
 
@@ -77,9 +79,11 @@ it('inline: exclusive other markdown syntax', () => {
 });
 
 it('display', () => {
-  const received = stringify('text$$1 + 1 = 2$$text', options);
-  const expected =
-    '<p>text<span class="math display">$$1 + 1 = 2$$</span>text</p>';
+  const md = `text$$1 + 1 = 2$$text
+$$a$$`;
+  const received = stringify(md, options);
+  const expected = `<p>text<span class="math display">$$1 + 1 = 2$$</span>text
+<span class="math display">$$a$$</span></p>`;
   expect(received).toBe(expected);
 });
 

--- a/tests/math.test.ts
+++ b/tests/math.test.ts
@@ -12,10 +12,77 @@ it('inline', () => {
   expect(received).toBe(expected);
 });
 
+it('inline: multiline', () => {
+  const md = `$x=y
+1 + 1 = 2$`;
+  const received = stringify(md, options);
+  const expected = `<p><span class="math inline">\\(x=y
+1 + 1 = 2\\)</span></p>`;
+  expect(received).toBe(expected);
+});
+
+it('inline: ignore "$ ...$"', () => {
+  const md = 'text $ text$x = y$';
+  const received = stringify(md, options);
+  const expected =
+    '<p>text $ text<span class="math inline">\\(x = y\\)</span></p>';
+  expect(received).toBe(expected);
+});
+
+it('inline: ignore "$... $"', () => {
+  const md = 'text $x = $y$ text';
+  const received = stringify(md, options);
+  const expected =
+    '<p>text <span class="math inline">\\(x = $y\\)</span> text</p>';
+  expect(received).toBe(expected);
+});
+
+it('inline: ignore "$" with number', () => {
+  const md = 'There are $3 and $4 bread.';
+  const received = stringify(md, options);
+  const expected = '<p>There are $3 and $4 bread.</p>';
+  expect(received).toBe(expected);
+});
+
+it('inline: ignore "$.\\$.$"', () => {
+  const md = 'text $x = 5\\$ + 4$ text';
+  const received = stringify(md, options);
+  const expected =
+    '<p>text <span class="math inline">\\(x = 5\\$ + 4\\)</span> text</p>';
+  expect(received).toBe(expected);
+});
+
+it('inline: exclusive other markdown syntax', () => {
+  const received = stringify('text$**bold**$text', options);
+  const expected =
+    '<p>text<span class="math inline">\\(**bold**\\)</span>text</p>';
+  expect(received).toBe(expected);
+});
+
 it('display', () => {
   const received = stringify('text$$1 + 1 = 2$$text', options);
   const expected =
     '<p>text<span class="math display">$$1 + 1 = 2$$</span>text</p>';
+  expect(received).toBe(expected);
+});
+
+it('display: multiline', () => {
+  const md = `$$
+x=y
+1 + 1 = 2
+$$`;
+  const received = stringify(md, options);
+  const expected = `<p><span class="math display">$$
+x=y
+1 + 1 = 2
+$$</span></p>`;
+  expect(received).toBe(expected);
+});
+
+it('display: exclusive other markdown syntax', () => {
+  const received = stringify('text$$**bold**$$text', options);
+  const expected =
+    '<p>text<span class="math display">$$**bold**$$</span>text</p>';
   expect(received).toBe(expected);
 });
 
@@ -29,23 +96,35 @@ it('inline and display', () => {
   expect(received).toBe(expected);
 });
 
-it('un-match', () => {
+it('un-match: $$$...', () => {
   const received = stringify('text$$$unmatch$$$text', options);
   const expected = '<p>text$$$unmatch$$$text</p>';
   expect(received).toBe(expected);
 });
 
-it('inline: exclusive other markdown syntax', () => {
-  const received = stringify('text$**bold**$text', options);
+it('un-match inline', () => {
+  const received = stringify('$x = y$ $ x = y$ $x = y $ $x = y$7', options);
   const expected =
-    '<p>text<span class="math inline">\\(**bold**\\)</span>text</p>';
+    '<p><span class="math inline">\\(x = y\\)</span> $ x = y$ $x = y $ $x = y$7</p>';
   expect(received).toBe(expected);
 });
 
-it('display: exclusive other markdown syntax', () => {
-  const received = stringify('text$$**bold**$$text', options);
-  const expected =
-    '<p>text<span class="math display">$$**bold**$$</span>text</p>';
+it('un-match: divided paragraph', () => {
+  const md = `$x = y
+
+1 + 1 = 2$
+$$
+x = y
+
+1 + 1 = 2
+$$`;
+  const received = stringify(md, options);
+  const expected = `<p>$x = y</p>
+<p>1 + 1 = 2$
+$$
+x = y</p>
+<p>1 + 1 = 2
+$$</p>`;
   expect(received).toBe(expected);
 });
 

--- a/tests/math.test.ts
+++ b/tests/math.test.ts
@@ -8,13 +8,14 @@ const options = {
 
 it('inline', () => {
   const received = stringify('text$x=y$text', options);
-  const expected = '<p>text\\(x=y\\)text</p>';
+  const expected = '<p>text<span class="math inline">\\(x=y\\)</span>text</p>';
   expect(received).toBe(expected);
 });
 
 it('display', () => {
   const received = stringify('text$$1 + 1 = 2$$text', options);
-  const expected = '<p>text$$1 + 1 = 2$$text</p>';
+  const expected =
+    '<p>text<span class="math display">$$1 + 1 = 2$$</span>text</p>';
   expect(received).toBe(expected);
 });
 
@@ -23,7 +24,8 @@ it('inline and display', () => {
     'inline: $x = y$\n\ndisplay: $$1 + 1 = 2$$',
     options,
   );
-  const expected = '<p>inline: \\(x = y\\)</p>\n<p>display: $$1 + 1 = 2$$</p>';
+  const expected = `<p>inline: <span class="math inline">\\(x = y\\)</span></p>
+<p>display: <span class="math display">$$1 + 1 = 2$$</span></p>`;
   expect(received).toBe(expected);
 });
 
@@ -35,13 +37,15 @@ it('un-match', () => {
 
 it('inline: exclusive other markdown syntax', () => {
   const received = stringify('text$**bold**$text', options);
-  const expected = '<p>text\\(**bold**\\)text</p>';
+  const expected =
+    '<p>text<span class="math inline">\\(**bold**\\)</span>text</p>';
   expect(received).toBe(expected);
 });
 
 it('display: exclusive other markdown syntax', () => {
   const received = stringify('text$$**bold**$$text', options);
-  const expected = '<p>text$$**bold**$$text</p>';
+  const expected =
+    '<p>text<span class="math display">$$**bold**$$</span>text</p>';
   expect(received).toBe(expected);
 });
 
@@ -55,7 +59,7 @@ it('HTML header and body', () => {
 <script async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-MML-AM_CHTML"></script>
 </head>
 <body data-math-typeset="true">
-<p>\\(x=y\\)</p>
+<p><span class="math inline">\\(x=y\\)</span></p>
 </body>
 </html>
 `;

--- a/tests/metadata.test.ts
+++ b/tests/metadata.test.ts
@@ -1,4 +1,4 @@
-import { stringify } from '../src/index';
+import { stringify, VFM } from '../src/index';
 
 it('all', () => {
   const received = stringify(
@@ -15,9 +15,9 @@ class: 'my-class'
 <html>
   <head>
     <meta charset="utf-8">
+    <title>Title</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="author" content="Author">
-    <title>Title</title>
   </head>
   <body class="my-class">
     <section id="page-title">
@@ -35,8 +35,8 @@ it('title from heading, missing "title" property of Frontmatter', () => {
 <html>
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Page Title</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
   <body>
     <section id="page-title">
@@ -68,6 +68,27 @@ class: 'my-class'
     <meta name="author" content="Author">
   </head>
   <body class="my-class"></body>
+</html>
+`;
+  expect(received).toBe(expected);
+});
+
+it('title with only frontmatter', () => {
+  const md = `---
+title: 'Title'
+---
+`;
+  const received = String(VFM().processSync(md));
+  // Since there is no option update that takes into account the stringify metadata,
+  // `<title>` is added to the end by your own processing instead of `rehype-document`.
+  const expected = `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Title</title>
+  </head>
+  <body></body>
 </html>
 `;
   expect(received).toBe(expected);

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -20,6 +20,7 @@ export const buildProcessorTestingCode = (
     replace = undefined,
     hardLineBreaks = false,
     disableFormatHtml = true,
+    math = false,
   }: StringifyMarkdownOptions = {},
 ) => (): any => {
   const vfm = VFM({
@@ -30,6 +31,7 @@ export const buildProcessorTestingCode = (
     replace,
     hardLineBreaks,
     disableFormatHtml,
+    math,
   }).freeze();
   expect(unistInspect.noColor(vfm.parse(input))).toBe(expectedMdast.trim());
   expect(String(vfm.processSync(input))).toBe(expectedHtml);

--- a/types/remark.d.ts
+++ b/types/remark.d.ts
@@ -10,6 +10,7 @@ declare module 'hast-util-is-element';
 declare module 'hastscript';
 declare module 'mdast-util-to-hast/lib/all';
 declare module 'mdast-util-to-string';
+declare module 'mdast-util-find-and-replace';
 declare module 'rehype-katex';
 declare module 'remark-slug';
 declare module 'rehype-slug';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4813,6 +4813,15 @@
   dependencies:
     "unist-util-visit" "^2.0.0"
 
+"mdast-util-find-and-replace@^1.1.1":
+  "integrity" "sha512-9cKl33Y21lyckGzpSmEQnIDjEfeeWelN5s1kUW1LwdB0Fkuq2u+4GdqcGEygYxJE8GVqCl0741bYXHgamfWAZA=="
+  "resolved" "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-1.1.1.tgz"
+  "version" "1.1.1"
+  dependencies:
+    "escape-string-regexp" "^4.0.0"
+    "unist-util-is" "^4.0.0"
+    "unist-util-visit-parents" "^3.0.0"
+
 "mdast-util-to-hast@^10.0.0", "mdast-util-to-hast@^10.1.1":
   "integrity" "sha512-+hvJrYiUgK2aY0Q1h1LaHQ4h0P7VVumWdAcUuG9k49lYglyU9GtTrA4O8hMh5gRnyT22wC15takM2qrrlpvNxQ=="
   "resolved" "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-10.1.1.tgz"
@@ -7338,15 +7347,7 @@
   dependencies:
     "unist-util-is" "^3.0.0"
 
-"unist-util-visit-parents@^3.0.0":
-  "integrity" "sha512-yJEfuZtzFpQmg1OSCyS9M5NJRrln/9FbYosH3iW0MG402QbdbaB8ZESwUv9RO6nRfLAKvWcMxCwdLWOov36x/g=="
-  "resolved" "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.0.2.tgz"
-  "version" "3.0.2"
-  dependencies:
-    "@types/unist" "^2.0.0"
-    "unist-util-is" "^4.0.0"
-
-"unist-util-visit-parents@^3.1.1":
+"unist-util-visit-parents@^3.0.0", "unist-util-visit-parents@^3.1.1":
   "integrity" "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg=="
   "resolved" "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz"
   "version" "3.1.1"


### PR DESCRIPTION
#37 の議論を踏まえて MathJax 形式の数式構文を実装しました。

@MurakamiShinyu @yamasy1549 
ドキュメント `docs/vfm.md` とテスト `tests/math.test.ts` のレビューをお願いします。

補足として当初は unified のみに依存する独自処理を実装していたのですが、remark を利用するとこれが拡張する tokenizer/method として登録しないと Markdown 構文間の排他がおこなわれないため、VFM 1.0 時点では仕方なく remark プラグインとすることにしました。

VFM 2.0 で remark 13 未満のインターフェースを判定して分岐しているため 13 以降では独自処理に切り替わるはずです。ただし remark 13 でも構文の排他は remark (micromark) として実装しないと機能しないと予想しています。