### PR TITLE
feat: Added section leveling

### DIFF
--- a/docs/vfm.md
+++ b/docs/vfm.md
@@ -203,21 +203,32 @@ ruby rt {
 # Introduction {#intro}
 
 # Welcome {.title}
+
+# Level 1
+
+## Level 2
 ```
 
 **HTML**
 
 ```html
-<section id="plain">
+<section id="plain" class="level1">
   <h1>Plain</h1>
 </section>
 
-<section id="intro">
+<section id="intro" class="level1">
   <h1>Introduction</h1>
 </section>
 
-<section id="welcome" class="title">
+<section class="level1 title" id="welcome">
   <h1>Welcome</h1>
+</section>
+
+<section id="level-1" class="level1">
+  <h1>Level 1</h1>
+  <section id="level-2" class="level2">
+    <h2>Level 2</h2>
+  </section>
 </section>
 ```
 
@@ -233,6 +244,11 @@ section.title {
 }
 
 section.title > h1:first-child {
+}
+
+.level1 {
+}
+.level2 {
 }
 ```
 

--- a/tests/attr.test.ts
+++ b/tests/attr.test.ts
@@ -2,7 +2,7 @@ import { stripIndent } from 'common-tags';
 import { buildProcessorTestingCode } from './utils';
 
 it(
-  'Header with attributes',
+  'Heading with attributes',
   buildProcessorTestingCode(
     `# Heading {#foo}`,
     stripIndent`
@@ -17,7 +17,7 @@ it(
 );
 
 it(
-  'Header with attributes, specification by line break',
+  'Heading with attributes, specification by line break',
   buildProcessorTestingCode(
     `# Heading\n{#foo}`,
     stripIndent`
@@ -32,7 +32,7 @@ it(
 );
 
 it(
-  'Header with attributes and inline elements, specification by line break',
+  'Heading with attributes and inline elements, specification by line break',
   buildProcessorTestingCode(
     `# Heading *test*\n{#foo}`,
     stripIndent`
@@ -52,7 +52,7 @@ it(
 // https://github.com/arobase-che/remark-attr/issues/24
 /*
 it(
-  'Header with attributes and inline elements',
+  'Heading with attributes and inline elements',
   buildProcessorTestingCode(
     `# Heading *test* {#foo}`,
     stripIndent`

--- a/tests/attr.test.ts
+++ b/tests/attr.test.ts
@@ -12,7 +12,7 @@ it(
         │ data: {"hProperties":{"id":"foo"}}
         └─0 text "Heading"
     `,
-    `<section id="foo"><h1>Heading</h1></section>`,
+    `<section id="foo" class="level1"><h1>Heading</h1></section>`,
   ),
 );
 
@@ -27,7 +27,7 @@ it(
         │ data: {"hProperties":{"id":"foo"}}
         └─0 text "Heading"
     `,
-    `<section id="foo"><h1>Heading</h1></section>`,
+    `<section id="foo" class="level1"><h1>Heading</h1></section>`,
   ),
 );
 
@@ -44,7 +44,7 @@ it(
         └─1 emphasis[1]
             └─0 text "test"
     `,
-    `<section id="foo"><h1>Heading <em>test</em></h1></section>`,
+    `<section id="foo" class="level1"><h1>Heading <em>test</em></h1></section>`,
   ),
 );
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,46 +1,6 @@
 import * as lib from '../src';
 import { ReplaceRule } from '../src/plugins/replace';
 
-/**
- * Run VFM stringify in partial mode.
- * @param body Markdown string that becomes `<body>` part.
- * @param hardLineBreaks Add `<br>` at the position of hard line breaks, without needing spaces.
- * @returns HTML string.
- */
-function partial(body: string, hardLineBreaks = false) {
-  return lib.stringify(body, {
-    partial: true,
-    hardLineBreaks,
-    disableFormatHtml: true,
-  });
-}
-
-// Snippet
-//
-// it('do something', ()=>{
-//   expect(partial(``)).toBe(``)
-// })
-
-it.skip('plain section', () => {
-  expect(partial(`# {.ok}`)).toBe(`<section class="ok"></section>`);
-});
-
-it('stringify markdown string into html document', () => {
-  expect(lib.stringify('# こんにちは', { disableFormatHtml: true }))
-    .toBe(`<!doctype html>
-<html>
-<head>
-<meta charset="utf-8">
-<title>こんにちは</title>
-<meta name="viewport" content="width=device-width, initial-scale=1">
-</head>
-<body>
-<section id="こんにちは"><h1>こんにちは</h1></section>
-</body>
-</html>
-`);
-});
-
 it('replace', () => {
   const rules = [
     {

--- a/tests/math.test.ts
+++ b/tests/math.test.ts
@@ -149,7 +149,7 @@ $$</p>`;
   expect(received).toBe(expected);
 });
 
-it('HTML header and body', () => {
+it('HTML heading and body', () => {
   const received = stringify('$x=y$', { math: true, disableFormatHtml: true });
   const expected = `<!doctype html>
 <html>

--- a/tests/math.test.ts
+++ b/tests/math.test.ts
@@ -149,7 +149,7 @@ $$</p>`;
   expect(received).toBe(expected);
 });
 
-it('HTML heading and body', () => {
+it('HTML head and body', () => {
   const received = stringify('$x=y$', { math: true, disableFormatHtml: true });
   const expected = `<!doctype html>
 <html>

--- a/tests/metadata.test.ts
+++ b/tests/metadata.test.ts
@@ -20,7 +20,7 @@ class: 'my-class'
     <meta name="author" content="Author">
   </head>
   <body class="my-class">
-    <section id="page-title">
+    <section id="page-title" class="level1">
       <h1>Page Title</h1>
     </section>
   </body>
@@ -39,7 +39,7 @@ it('title from heading, missing "title" property of Frontmatter', () => {
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
   <body>
-    <section id="page-title">
+    <section id="page-title" class="level1">
       <h1>Page Title</h1>
     </section>
   </body>
@@ -142,7 +142,7 @@ class: 'my-class'
     <meta name="author" content="Author">
   </head>
   <body class="my-class">
-    <section id="heading-title">
+    <section id="heading-title" class="level1">
       <h1>Heading Title</h1>
     </section>
   </body>

--- a/tests/section.test.ts
+++ b/tests/section.test.ts
@@ -26,26 +26,26 @@ it('<h7> is not heading', () => {
 });
 
 it('<h1>, ... <h6>', () => {
-  const md = `# Header 1
-## Header 2
-### Header 3
-#### Header 4
-##### Header 5
-###### Header 6`;
+  const md = `# Heading 1
+## Heading 2
+### Heading 3
+#### Heading 4
+##### Heading 5
+###### Heading 6`;
   const received = stringify(md, { partial: true });
   const expected = `
-<section id="header-1" class="level1">
-  <h1>Header 1</h1>
-  <section id="header-2" class="level2">
-    <h2>Header 2</h2>
-    <section id="header-3" class="level3">
-      <h3>Header 3</h3>
-      <section id="header-4" class="level4">
-        <h4>Header 4</h4>
-        <section id="header-5" class="level5">
-          <h5>Header 5</h5>
-          <section id="header-6" class="level6">
-            <h6>Header 6</h6>
+<section id="heading-1" class="level1">
+  <h1>Heading 1</h1>
+  <section id="heading-2" class="level2">
+    <h2>Heading 2</h2>
+    <section id="heading-3" class="level3">
+      <h3>Heading 3</h3>
+      <section id="heading-4" class="level4">
+        <h4>Heading 4</h4>
+        <section id="heading-5" class="level5">
+          <h5>Heading 5</h5>
+          <section id="heading-6" class="level6">
+            <h6>Heading 6</h6>
           </section>
         </section>
       </section>
@@ -58,26 +58,26 @@ it('<h1>, ... <h6>', () => {
 
 // It seems that when the class is processed by `remark-attr`, it is output before id.
 it('<h1>, ... <h6> with attribute', () => {
-  const md = `# Header 1 {.depth1}
-## Header 2 {.depth2}
-### Header 3 {.depth3}
-#### Header 4 {.depth4}
-##### Header 5 {.depth5}
-###### Header 6 {.depth6}`;
+  const md = `# Heading 1 {.depth1}
+## Heading 2 {.depth2}
+### Heading 3 {.depth3}
+#### Heading 4 {.depth4}
+##### Heading 5 {.depth5}
+###### Heading 6 {.depth6}`;
   const received = stringify(md, { partial: true });
   const expected = `
-<section class="level1 depth1" id="header-1">
-  <h1>Header 1</h1>
-  <section class="level2 depth2" id="header-2">
-    <h2>Header 2</h2>
-    <section class="level3 depth3" id="header-3">
-      <h3>Header 3</h3>
-      <section class="level4 depth4" id="header-4">
-        <h4>Header 4</h4>
-        <section class="level5 depth5" id="header-5">
-          <h5>Header 5</h5>
-          <section class="level6 depth6" id="header-6">
-            <h6>Header 6</h6>
+<section class="level1 depth1" id="heading-1">
+  <h1>Heading 1</h1>
+  <section class="level2 depth2" id="heading-2">
+    <h2>Heading 2</h2>
+    <section class="level3 depth3" id="heading-3">
+      <h3>Heading 3</h3>
+      <section class="level4 depth4" id="heading-4">
+        <h4>Heading 4</h4>
+        <section class="level5 depth5" id="heading-5">
+          <h5>Heading 5</h5>
+          <section class="level6 depth6" id="heading-6">
+            <h6>Heading 6</h6>
           </section>
         </section>
       </section>
@@ -89,19 +89,19 @@ it('<h1>, ... <h6> with attribute', () => {
 });
 
 it('Complex structure', () => {
-  const md = `# Header 1
-## Header 2 {.foo}
-# Header 1`;
+  const md = `# Heading 1
+## Heading 2 {.foo}
+# Heading 1`;
   const received = stringify(md, { partial: true });
   const expected = `
-<section id="header-1" class="level1">
-  <h1>Header 1</h1>
-  <section class="level2 foo" id="header-2">
-    <h2>Header 2</h2>
+<section id="heading-1" class="level1">
+  <h1>Heading 1</h1>
+  <section class="level2 foo" id="heading-2">
+    <h2>Heading 2</h2>
   </section>
 </section>
-<section id="header-1-1" class="level1">
-  <h1>Header 1</h1>
+<section id="heading-1-1" class="level1">
+  <h1>Heading 1</h1>
 </section>
 `;
   expect(received).toBe(expected);

--- a/tests/section.test.ts
+++ b/tests/section.test.ts
@@ -1,0 +1,108 @@
+import { stringify } from '../src/index';
+
+// This test always fails, `remark-attr` does not handle empty headings.
+/*
+it('plain section', () => {
+  const md = '# {.ok}';
+  const received = stringify(md, { partial: true, disableFormatHtml: true });
+  const expected = '<section class="level1 ok"></section>';
+  expect(received).toBe(expected);
+});
+*/
+
+it('<h1>', () => {
+  const md = '# こんにちは {.test}';
+  const received = stringify(md, { partial: true, disableFormatHtml: true });
+  const expected =
+    '<section class="level1 test" id="こんにちは"><h1>こんにちは</h1></section>';
+  expect(received).toBe(expected);
+});
+
+it('<h7> is not heading', () => {
+  const md = '####### こんにちは {.test}';
+  const received = stringify(md, { partial: true, disableFormatHtml: true });
+  const expected = '<p>####### こんにちは {.test}</p>';
+  expect(received).toBe(expected);
+});
+
+it('<h1>, ... <h6>', () => {
+  const md = `# Header 1
+## Header 2
+### Header 3
+#### Header 4
+##### Header 5
+###### Header 6`;
+  const received = stringify(md, { partial: true });
+  const expected = `
+<section id="header-1" class="level1">
+  <h1>Header 1</h1>
+  <section id="header-2" class="level2">
+    <h2>Header 2</h2>
+    <section id="header-3" class="level3">
+      <h3>Header 3</h3>
+      <section id="header-4" class="level4">
+        <h4>Header 4</h4>
+        <section id="header-5" class="level5">
+          <h5>Header 5</h5>
+          <section id="header-6" class="level6">
+            <h6>Header 6</h6>
+          </section>
+        </section>
+      </section>
+    </section>
+  </section>
+</section>
+`;
+  expect(received).toBe(expected);
+});
+
+// It seems that when the class is processed by `remark-attr`, it is output before id.
+it('<h1>, ... <h6> with attribute', () => {
+  const md = `# Header 1 {.depth1}
+## Header 2 {.depth2}
+### Header 3 {.depth3}
+#### Header 4 {.depth4}
+##### Header 5 {.depth5}
+###### Header 6 {.depth6}`;
+  const received = stringify(md, { partial: true });
+  const expected = `
+<section class="level1 depth1" id="header-1">
+  <h1>Header 1</h1>
+  <section class="level2 depth2" id="header-2">
+    <h2>Header 2</h2>
+    <section class="level3 depth3" id="header-3">
+      <h3>Header 3</h3>
+      <section class="level4 depth4" id="header-4">
+        <h4>Header 4</h4>
+        <section class="level5 depth5" id="header-5">
+          <h5>Header 5</h5>
+          <section class="level6 depth6" id="header-6">
+            <h6>Header 6</h6>
+          </section>
+        </section>
+      </section>
+    </section>
+  </section>
+</section>
+`;
+  expect(received).toBe(expected);
+});
+
+it('Complex structure', () => {
+  const md = `# Header 1
+## Header 2 {.foo}
+# Header 1`;
+  const received = stringify(md, { partial: true });
+  const expected = `
+<section id="header-1" class="level1">
+  <h1>Header 1</h1>
+  <section class="level2 foo" id="header-2">
+    <h2>Header 2</h2>
+  </section>
+</section>
+<section id="header-1-1" class="level1">
+  <h1>Header 1</h1>
+</section>
+`;
+  expect(received).toBe(expected);
+});


### PR DESCRIPTION
#8 で要望されていた機能のうち、

> - Pandoc では section 要素に class 属性 "level1" 〜 "level6" が出力される
>   - これがあると CSS でレベルごとの section のスタイルを指定しやすいので、vfm にもほしい

へ対応してみました。懸念点として `remark-attr` の処理が走ると `id` と `class` の順番が入れ替わる謎の挙動があります。ただしこのプラグイン処理には関与できないのと HTML/CSS 的に属性の定義順へ強く依存するものはないと思われますので実用十分と判断しました。

これを先に実装したのは想定よりも影響範囲が少なくて済みそうであったためです。他の要望については別途、対応を検討します。

@MurakamiShinyu 
ドキュメント `docs/vfm.md` とテスト `test/section.test.ts` についてレビューをお願いします。
