### PR TITLE
feat: Disable section with blockquote heading

### DIFF
--- a/docs/vfm.md
+++ b/docs/vfm.md
@@ -193,12 +193,13 @@ ruby rt {
 
 ## Sectionization
 
-<Badge type="warning">PRE-RELEASE</Badge>
+Make the heading a hierarchical section.
 
-If specify the attribute in the heading, it will be as follows.
-
-- `id` is moved to `<section>`
-- Other attributes are copied to `<section>`
+- Do not sectionize if parent is `blockquote`.
+- The attributes of the heading are basically copied to the section.
+- The `id` attribute is moved to the section.
+- The `hidden` attribute is not copied and only the heading applies.
+- Set the `levelN` class in the section to match the heading depth.
 
 **VFM**
 
@@ -212,6 +213,8 @@ If specify the attribute in the heading, it will be as follows.
 # Level 1
 
 ## Level 2
+
+> # Not Sectionize
 ```
 
 **HTML**
@@ -235,6 +238,10 @@ If specify the attribute in the heading, it will be as follows.
     <h2>Level 2</h2>
   </section>
 </section>
+
+<blockquote>
+  <h1 id="not-sectionize">Not Sectionize</h1>
+</blockquote>
 ```
 
 **CSS**
@@ -254,6 +261,9 @@ section.title > h1:first-child {
 .level1 {
 }
 .level2 {
+}
+
+blockquote > h1 {
 }
 ```
 

--- a/src/plugins/section.ts
+++ b/src/plugins/section.ts
@@ -31,7 +31,7 @@ const checkProperties = (node: any, depth: number) => {
 
   // {hidden} specifier
   if (Object.keys(hProperties).includes('hidden')) {
-    node.data.hProperties.hidden = "hidden";
+    node.data.hProperties.hidden = 'hidden';
   }
 
   // output section levels like Pandoc
@@ -50,14 +50,23 @@ const checkProperties = (node: any, depth: number) => {
 
 /**
  * Wrap the header in sections.
+ * - Do not sectionize if parent is `blockquote`.
+ * - The attributes of the heading are basically copied to the section.
+ * - The `id` attribute is moved to the section.
+ * - The `hidden` attribute is not copied and only the heading applies.
+ * - Set the `levelN` class in the section to match the heading depth.
  * @param node Node of Markdown AST.
  * @param ancestors Parents.
  * @todo handle `@subtitle` properly.
  */
 const sectionize = (node: any, ancestors: Parent[]) => {
+  const parent = ancestors[ancestors.length - 1];
+  if (parent.type === 'blockquote') {
+    return;
+  }
+
   const start = node;
   const depth = start.depth;
-  const parent = ancestors[ancestors.length - 1];
 
   const isEnd = (node: any) =>
     (node.type === 'heading' && node.depth <= depth) || node.type === 'export';

--- a/tests/section.test.ts
+++ b/tests/section.test.ts
@@ -29,6 +29,17 @@ it('Heading with hidden attribute', () => {
   expect(received).toBe(expected);
 });
 
+it('Disable section with blockquote heading', () => {
+  const md = '> # Not Sectionize';
+  const received = stringify(md, { partial: true });
+  const expected = `
+<blockquote>
+  <h1 id="not-sectionize">Not Sectionize</h1>
+</blockquote>
+`;
+  expect(received).toBe(expected);
+});
+
 it('<h7> is not heading', () => {
   const md = '####### こんにちは {.test}';
   const received = stringify(md, { partial: true, disableFormatHtml: true });


### PR DESCRIPTION
#8 のうち以下に対応。

> 3. Pandoc では blockquote 内の見出し（例 `> # Heading`）では section は作られない
>     - blockquote の内容は本文とは違うものなので、sectionによる構造化の対象にはしないということだろう

@MurakamiShinyu 
レビューお願いします。セクション系の対応が累積しているので `docs/vfm.md` へも属性の扱いなどをまとめて列挙しておきました。