### PR TITLE
feat: Math syntax enabled default

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Vivliostyle Flavored Markdown (VFM), a Markdown syntax optimized for book author
     - [`language` (default: `undefined`)](#language-default-undefined)
     - [`hardLineBreaks` (default: `false`)](#hardLineBreaks-default-false)
     - [`disableFormatHtml` (default: `false`)](#disableFormatHtml-default-false)
+    - [`math` (default: `true`)](#math-default-true)
   - [Advanced usage](#advanced-usage)
     - [Unified processor](#unified-processor)
     - [Unified plugin](#unified-plugin)
@@ -267,6 +268,56 @@ will generates:
 <body>
 <p>text</p>
 </body>
+</html>
+```
+
+#### `math` (default: `true`)
+
+Handles math syntax. The default value is `true`, which is valid.
+
+```js
+stringify(
+  `$x = y$`
+);
+```
+
+will generates:
+
+```html
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-MML-AM_CHTML"></script>
+  </head>
+  <body data-math-typeset="true">
+    <p><span class="math inline">\(x = y\)</span></p>
+  </body>
+</html>
+```
+
+To explicitly disable it, specify `false` for this option or `math: false` for Markdown's Frontmatter.
+
+```js
+stringify(
+  `$x = y$`,
+  { math: false }
+);
+```
+
+will generates:
+
+```html
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body>
+    <p>$x = y$</p>
+  </body>
 </html>
 ```
 

--- a/docs/vfm.md
+++ b/docs/vfm.md
@@ -368,7 +368,7 @@ display: $$1 + 1 = 2$$
 
 **HTML**
 
-It also outputs `<script>` for processing MathJax in Vivliostyle if `math` is enabled. However, even if the math syntax is valid, it will not be output if it does not actually exist.
+It also outputs `<script>` for processing MathJax in Vivliostyle if `math` is enabled. However, the math syntax or the `<math>` tag must actually exist.
 
 ```html
 <html>

--- a/docs/vfm.md
+++ b/docs/vfm.md
@@ -368,7 +368,7 @@ display: $$1 + 1 = 2$$
 
 **HTML**
 
-It also outputs the `<script>` and `<body>` attributes for processing MathJax in Vivliostyle if `math` is enabled. However, even if the math syntax is valid, it will not be output if it does not actually exist.
+It also outputs `<script>` for processing MathJax in Vivliostyle if `math` is enabled. However, even if the math syntax is valid, it will not be output if it does not actually exist.
 
 ```html
 <html>
@@ -377,9 +377,9 @@ It also outputs the `<script>` and `<body>` attributes for processing MathJax in
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-MML-AM_CHTML"></script>
   </head>
-  <body data-math-typeset="true">
-    <p>inline: <span class="math inline">\(x = y\)</span></p>
-    <p>display: <span class="math display">$$1 + 1 = 2$$</span></p>
+  <body>
+    <p>inline: <span class="math inline" data-math-typeset="true>"\(x = y\)</span></p>
+    <p>display: <span class="math display" data-math-typeset="true">$$1 + 1 = 2$$</span></p>
   </body>
 </html>
 ```

--- a/docs/vfm.md
+++ b/docs/vfm.md
@@ -332,11 +332,13 @@ section.author {
 
 Outputs HTML processed by [MathJax](https://www.mathjax.org/).
 
-It is disabled by default. It is activated by satisfying one of the following.
+It is Enabled by default. To disable it, specify the following.
 
-- VFM options: `math: true`
-- CLI options: `--math`
-- Frontmatter: `math: true` (Priority over others)
+- `stringify` API options: `math: false`
+- `VFM` API options: `math: false`
+- CLI options: `--disable-math`
+- Frontmatter: `math: false`
+  - It takes precedence over `stringify`, but` VFM` does not.
 
 The VFM syntax for MathJax inline is `$...$` and the display is `$$...$$`.
 
@@ -366,7 +368,7 @@ display: $$1 + 1 = 2$$
 
 **HTML**
 
-It also outputs the `<script>` and `<body>` attributes for processing MathJax in Vivliostyle if `math` is enabled.
+It also outputs the `<script>` and `<body>` attributes for processing MathJax in Vivliostyle if `math` is enabled. However, even if the math syntax is valid, it will not be output if it does not actually exist.
 
 ```html
 <html>
@@ -424,8 +426,9 @@ The priority of `title` is as follows.
 
 The priority of `math` is as follows.
 
-1. `math` property of the frontmatter
-2. `math` option of VFM
+1. `math` option of `VFM` API
+2. `math` property of the frontmatter
+3. `math` option of `stringify` API
 
 **class**
 

--- a/docs/vfm.md
+++ b/docs/vfm.md
@@ -368,7 +368,7 @@ display: $$1 + 1 = 2$$
 
 **HTML**
 
-It also outputs `<script>` for processing MathJax in Vivliostyle if `math` is enabled. However, the math syntax or the `<math>` tag must actually exist.
+It also outputs `<script>` for processing MathJax if `math` is enabled and the math syntax or the `<math>` tag is actually existed.
 
 ```html
 <html>

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "debug": "^4.3.1",
     "hast-util-find-and-replace": "^3.2.0",
     "hast-util-is-element": "^1.1.0",
+    "hast-util-select": "^4.0.2",
     "hastscript": "^6.0.0",
     "js-yaml": "^4.0.0",
     "mdast-util-find-and-replace": "^1.1.1",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,7 +18,7 @@ const cli = meow(
       --language             Document language (ignored in partial mode)
       --hard-line-breaks     Add <br> at the position of hard line breaks, without needing spaces
       --disable-format-html  Disable automatic HTML format
-      --math                 Enable math syntax
+      --disable-math         Disable math syntax
  
     Examples
       $ vfm input.md
@@ -46,7 +46,7 @@ const cli = meow(
       disableFormatHtml: {
         type: 'boolean',
       },
-      math: {
+      disableMath: {
         type: 'boolean',
       },
     },
@@ -63,7 +63,7 @@ function compile(input: string) {
       language: cli.flags.language,
       hardLineBreaks: cli.flags.hardLineBreaks,
       disableFormatHtml: cli.flags.disableFormatHtml,
-      math: cli.flags.math,
+      math: cli.flags.disableMath === undefined ? true : !cli.flags.disableMath,
     }),
   );
 }
@@ -76,7 +76,7 @@ function main(
     language: { type: 'string' };
     hardLineBreaks: { type: 'boolean' };
     disableFormatHtml: { type: 'boolean' };
-    math: { type: 'boolean' };
+    disableMath: { type: 'boolean' };
   }>,
 ) {
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,7 @@ export function VFM({
   replace = undefined,
   hardLineBreaks = false,
   disableFormatHtml = false,
-  math = false,
+  math = true,
 }: StringifyMarkdownOptions = {}): Processor {
   const processor = unified()
     .use(markdown(hardLineBreaks, math))

--- a/src/plugins/math.ts
+++ b/src/plugins/math.ts
@@ -208,11 +208,11 @@ export const handlerDisplayMath: Handler = (h, node: Node) => {
  * This function does the work even if it finds a `<math>` that it does not treat as a VFM. Therefore, call it only if the VFM option is `math: true`.
  */
 export const hast = () => (tree: Node) => {
-  if (!MATH_PROCESSED && !select('math', tree)) {
+  const isMathProcessed = MATH_PROCESSED;
+  MATH_PROCESSED = false;
+  if (!(isMathProcessed || select('math', tree))) {
     return;
   }
-
-  MATH_PROCESSED = false;
 
   visit<Element>(tree, 'element', (node) => {
     switch (node.tagName) {

--- a/src/plugins/math.ts
+++ b/src/plugins/math.ts
@@ -207,7 +207,7 @@ export const handlerDisplayMath: Handler = (h, node: Node) => {
  *
  * This function does the work even if it finds a `<math>` that it does not treat as a VFM. Therefore, call it only if the VFM option is `math: true`.
  */
-export const hast = () => (tree: Element) => {
+export const hast = () => (tree: Node) => {
   if (!MATH_PROCESSED && !select('math', tree)) {
     return;
   }

--- a/src/plugins/math.ts
+++ b/src/plugins/math.ts
@@ -27,9 +27,6 @@ const TYPE_DISPLAY = 'displayMath';
 const MATH_URL =
   'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-MML-AM_CHTML';
 
-/** The flag indicates that math syntax was actually processed. */
-let MATH_PROCESSED = false;
-
 /**
  * Create tokenizers for remark-parse.
  * @returns Tokenizers.
@@ -109,8 +106,6 @@ const createTokenizers = () => {
  * @returns Transformer or undefined (less than remark 13).
  */
 export const mdast: Plugin = function (): Transformer | undefined {
-  MATH_PROCESSED = false;
-
   // For less than remark 13 with exclusive other markdown syntax
   if (
     this.Parser &&
@@ -162,8 +157,6 @@ export const handlerInlineMath: Handler = (h, node: Node) => {
     node.data = {};
   }
 
-  MATH_PROCESSED = true;
-
   return h(
     {
       type: 'element',
@@ -184,9 +177,9 @@ export const handlerInlineMath: Handler = (h, node: Node) => {
  * @returns Hypertext AST.
  */
 export const handlerDisplayMath: Handler = (h, node: Node) => {
-  if (!node.data) node.data = {};
-
-  MATH_PROCESSED = true;
+  if (!node.data) {
+    node.data = {};
+  }
 
   return h(
     {
@@ -208,9 +201,7 @@ export const handlerDisplayMath: Handler = (h, node: Node) => {
  * This function does the work even if it finds a `<math>` that it does not treat as a VFM. Therefore, call it only if the VFM option is `math: true`.
  */
 export const hast = () => (tree: Node) => {
-  const isMathProcessed = MATH_PROCESSED;
-  MATH_PROCESSED = false;
-  if (!(isMathProcessed || select('math', tree))) {
+  if (!(select('[data-math-typeset="true"]', tree) || select('math', tree))) {
     return;
   }
 

--- a/src/plugins/math.ts
+++ b/src/plugins/math.ts
@@ -170,6 +170,7 @@ export const handlerInlineMath: Handler = (h, node: Node) => {
     'span',
     {
       class: 'math inline',
+      'data-math-typeset': 'true',
     },
     [u('text', `\\(${node.data.value as string}\\)`)],
   );
@@ -193,6 +194,7 @@ export const handlerDisplayMath: Handler = (h, node: Node) => {
     'span',
     {
       class: 'math display',
+      'data-math-typeset': 'true',
     },
     [u('text', `$$${node.data.value as string}$$`)],
   );
@@ -222,10 +224,6 @@ export const hast = () => (tree: Node) => {
           children: [],
         });
         node.children.push({ type: 'text', value: '\n' });
-        break;
-
-      case 'body':
-        node.properties = { ...node.properties, 'data-math-typeset': 'true' };
         break;
     }
   });

--- a/src/plugins/math.ts
+++ b/src/plugins/math.ts
@@ -1,4 +1,5 @@
 import { Element } from 'hast';
+import { select } from 'hast-util-select';
 import findReplace from 'mdast-util-find-and-replace';
 import { Handler } from 'mdast-util-to-hast';
 import { Plugin, Transformer } from 'unified';
@@ -203,9 +204,11 @@ export const handlerDisplayMath: Handler = (h, node: Node) => {
 /**
  * Process math related Hypertext AST.
  * Set the `<script>` to load MathJax and `<body>` attribute that enable math typesetting.
+ *
+ * This function does the work even if it finds a `<math>` that it does not treat as a VFM. Therefore, call it only if the VFM option is `math: true`.
  */
-export const hast = () => (tree: Node) => {
-  if (!MATH_PROCESSED) {
+export const hast = () => (tree: Element) => {
+  if (!MATH_PROCESSED && !select('math', tree)) {
     return;
   }
 

--- a/tests/math.test.ts
+++ b/tests/math.test.ts
@@ -3,7 +3,6 @@ import { stringify } from '../src/index';
 const options = {
   partial: true,
   disableFormatHtml: true,
-  math: true,
 };
 
 it('inline', () => {
@@ -166,7 +165,38 @@ it('HTML head and body', () => {
   expect(received).toBe(expected);
 });
 
-it('disable', () => {
+it('math syntax does not exist, without <script> and <body> attribute', () => {
+  const md = 'Sample';
+  const received = stringify(md, {
+    math: false,
+    disableFormatHtml: true,
+  });
+  const expected = `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+<p>Sample</p>
+</body>
+</html>
+`;
+  expect(received).toBe(expected);
+});
+
+it('disable with options', () => {
+  const md = '$x = y$';
+  const received = stringify(md, {
+    math: false,
+    partial: true,
+    disableFormatHtml: true,
+  });
+  const expected = '<p>$x = y$</p>';
+  expect(received).toBe(expected);
+});
+
+it('disable with frontmatter, override options', () => {
   const markdown = `---
 math: false
 ---

--- a/tests/math.test.ts
+++ b/tests/math.test.ts
@@ -165,6 +165,45 @@ it('Output <script> tag', () => {
   expect(received).toBe(expected);
 });
 
+it('Output <script> if <math> tag exists', () => {
+  const md = '- MathML: <math><mi>x</mi><mo>=</mo><mi>y</mi></math>.';
+  const received = stringify(md, { disableFormatHtml: true });
+  const expected = `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-MML-AM_CHTML"></script>
+</head>
+<body>
+<ul>
+<li>MathML: <math><mi>x</mi><mo>=</mo><mi>y</mi></math>.</li>
+</ul>
+</body>
+</html>
+`;
+  expect(received).toBe(expected);
+});
+
+it('Not output <script> if <math> tag exists with disable math syntax', () => {
+  const md = '- MathML: <math><mi>x</mi><mo>=</mo><mi>y</mi></math>.';
+  const received = stringify(md, { math: false, disableFormatHtml: true });
+  const expected = `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+<ul>
+<li>MathML: <math><mi>x</mi><mo>=</mo><mi>y</mi></math>.</li>
+</ul>
+</body>
+</html>
+`;
+  expect(received).toBe(expected);
+});
+
 it('math syntax does not exist, without <script> tag', () => {
   const md = 'Sample';
   const received = stringify(md, {

--- a/tests/math.test.ts
+++ b/tests/math.test.ts
@@ -11,10 +11,10 @@ $a$
 $(x = y)$
 $|x = y|$`;
   const received = stringify(md, options);
-  const expected = `<p>text<span class="math inline">\\(x = y\\)</span>text
-<span class="math inline">\\(a\\)</span>
-<span class="math inline">\\((x = y)\\)</span>
-<span class="math inline">\\(|x = y|\\)</span></p>`;
+  const expected = `<p>text<span class="math inline" data-math-typeset="true">\\(x = y\\)</span>text
+<span class="math inline" data-math-typeset="true">\\(a\\)</span>
+<span class="math inline" data-math-typeset="true">\\((x = y)\\)</span>
+<span class="math inline" data-math-typeset="true">\\(|x = y|\\)</span></p>`;
   expect(received).toBe(expected);
 });
 
@@ -22,7 +22,7 @@ it('inline: multiline', () => {
   const md = `$x = y
 1 + 1 = 2$`;
   const received = stringify(md, options);
-  const expected = `<p><span class="math inline">\\(x = y
+  const expected = `<p><span class="math inline" data-math-typeset="true">\\(x = y
 1 + 1 = 2\\)</span></p>`;
   expect(received).toBe(expected);
 });
@@ -34,7 +34,7 @@ x = y$
 $\tx = y$
 `;
   const received = stringify(md, options);
-  const expected = `<p>text $ text<span class="math inline">\\(x = y\\)</span>
+  const expected = `<p>text $ text<span class="math inline" data-math-typeset="true">\\(x = y\\)</span>
 $
 x = y$
 $\tx = y$</p>`;
@@ -48,7 +48,7 @@ $
 $x = y\t$
 `;
   const received = stringify(md, options);
-  const expected = `<p>text <span class="math inline">\\(x = $y\\)</span> text
+  const expected = `<p>text <span class="math inline" data-math-typeset="true">\\(x = $y\\)</span> text
 $x = y
 $
 $x = y\t$</p>`;
@@ -66,14 +66,14 @@ it('inline: ignore "$.\\$.$"', () => {
   const md = 'text $x = 5\\$ + \\\\\\$ + 4$ text';
   const received = stringify(md, options);
   const expected =
-    '<p>text <span class="math inline">\\(x = 5\\$ + \\\\\\$ + 4\\)</span> text</p>';
+    '<p>text <span class="math inline" data-math-typeset="true">\\(x = 5\\$ + \\\\\\$ + 4\\)</span> text</p>';
   expect(received).toBe(expected);
 });
 
 it('inline: exclusive other markdown syntax', () => {
   const received = stringify('text$**bold**$text', options);
   const expected =
-    '<p>text<span class="math inline">\\(**bold**\\)</span>text</p>';
+    '<p>text<span class="math inline" data-math-typeset="true">\\(**bold**\\)</span>text</p>';
   expect(received).toBe(expected);
 });
 
@@ -81,8 +81,8 @@ it('display', () => {
   const md = `text$$1 + 1 = 2$$text
 $$a$$`;
   const received = stringify(md, options);
-  const expected = `<p>text<span class="math display">$$1 + 1 = 2$$</span>text
-<span class="math display">$$a$$</span></p>`;
+  const expected = `<p>text<span class="math display" data-math-typeset="true">$$1 + 1 = 2$$</span>text
+<span class="math display" data-math-typeset="true">$$a$$</span></p>`;
   expect(received).toBe(expected);
 });
 
@@ -92,7 +92,7 @@ x=y
 1 + 1 = 2
 $$`;
   const received = stringify(md, options);
-  const expected = `<p><span class="math display">$$
+  const expected = `<p><span class="math display" data-math-typeset="true">$$
 x=y
 1 + 1 = 2
 $$</span></p>`;
@@ -102,7 +102,7 @@ $$</span></p>`;
 it('display: exclusive other markdown syntax', () => {
   const received = stringify('text$$**bold**$$text', options);
   const expected =
-    '<p>text<span class="math display">$$**bold**$$</span>text</p>';
+    '<p>text<span class="math display" data-math-typeset="true">$$**bold**$$</span>text</p>';
   expect(received).toBe(expected);
 });
 
@@ -111,8 +111,8 @@ it('inline and display', () => {
     'inline: $x = y$\n\ndisplay: $$1 + 1 = 2$$',
     options,
   );
-  const expected = `<p>inline: <span class="math inline">\\(x = y\\)</span></p>
-<p>display: <span class="math display">$$1 + 1 = 2$$</span></p>`;
+  const expected = `<p>inline: <span class="math inline" data-math-typeset="true">\\(x = y\\)</span></p>
+<p>display: <span class="math display" data-math-typeset="true">$$1 + 1 = 2$$</span></p>`;
   expect(received).toBe(expected);
 });
 
@@ -125,7 +125,7 @@ it('un-match: $$$...', () => {
 it('un-match inline', () => {
   const received = stringify('$x = y$ $ x = y$ $x = y $ $x = y$7', options);
   const expected =
-    '<p><span class="math inline">\\(x = y\\)</span> $ x = y$ $x = y $ $x = y$7</p>';
+    '<p><span class="math inline" data-math-typeset="true">\\(x = y\\)</span> $ x = y$ $x = y $ $x = y$7</p>';
   expect(received).toBe(expected);
 });
 
@@ -148,7 +148,7 @@ $$</p>`;
   expect(received).toBe(expected);
 });
 
-it('HTML head and body', () => {
+it('Output <script> tag', () => {
   const received = stringify('$x=y$', { math: true, disableFormatHtml: true });
   const expected = `<!doctype html>
 <html>
@@ -157,15 +157,15 @@ it('HTML head and body', () => {
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <script async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-MML-AM_CHTML"></script>
 </head>
-<body data-math-typeset="true">
-<p><span class="math inline">\\(x=y\\)</span></p>
+<body>
+<p><span class="math inline" data-math-typeset="true">\\(x=y\\)</span></p>
 </body>
 </html>
 `;
   expect(received).toBe(expected);
 });
 
-it('math syntax does not exist, without <script> and <body> attribute', () => {
+it('math syntax does not exist, without <script> tag', () => {
   const md = 'Sample';
   const received = stringify(md, {
     math: false,

--- a/types/remark.d.ts
+++ b/types/remark.d.ts
@@ -7,6 +7,7 @@ declare module 'rehype-raw' {
 declare module 'hast-util-find-and-replace';
 declare module 'remark-shortcodes';
 declare module 'hast-util-is-element';
+declare module 'hast-util-select';
 declare module 'hastscript';
 declare module 'mdast-util-to-hast/lib/all';
 declare module 'mdast-util-to-string';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1371,6 +1371,11 @@
     "mixin-deep" "^1.2.0"
     "pascalcase" "^0.1.1"
 
+"bcp-47-match@^1.0.0":
+  "integrity" "sha512-LggQ4YTdjWQSKELZF5JwchnBa1u0pIQSZf5lSdOHEdbVP55h0qICA/FUp3+W99q0xqxYa1ZQizTUH87gecII5w=="
+  "resolved" "https://registry.npmjs.org/bcp-47-match/-/bcp-47-match-1.0.3.tgz"
+  "version" "1.0.3"
+
 "bcrypt-pbkdf@^1.0.0":
   "integrity" "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4="
   "resolved" "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz"
@@ -2274,6 +2279,11 @@
   "version" "3.0.1"
   dependencies:
     "path-type" "^4.0.0"
+
+"direction@^1.0.0":
+  "integrity" "sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ=="
+  "resolved" "https://registry.npmjs.org/direction/-/direction-1.0.4.tgz"
+  "version" "1.0.4"
 
 "doctrine@^3.0.0":
   "integrity" "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="
@@ -3297,12 +3307,7 @@
     "hast-util-has-property" "^1.0.0"
     "hast-util-is-element" "^1.0.0"
 
-"hast-util-is-element@^1.0.0":
-  "integrity" "sha512-NFR6ljJRvDcyPP5SbV7MyPBgF47X3BsskLnmw1U34yL+X6YC0MoBx9EyMg8Jtx4FzGH95jw8+c1VPLHaRA0wDQ=="
-  "resolved" "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-1.0.4.tgz"
-  "version" "1.0.4"
-
-"hast-util-is-element@^1.1.0":
+"hast-util-is-element@^1.0.0", "hast-util-is-element@^1.1.0":
   "integrity" "sha512-oUmNua0bFbdrD/ELDSSEadRVtWZOf3iF6Lbv81naqsIV99RnSCieTbWuWCY8BAeEfKJTKl0gRdokv+dELutHGQ=="
   "resolved" "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-1.1.0.tgz"
   "version" "1.1.0"
@@ -3338,6 +3343,26 @@
     "xtend" "^4.0.0"
     "zwitch" "^1.0.0"
 
+"hast-util-select@^4.0.2":
+  "integrity" "sha512-8EEG2//bN5rrzboPWD2HdS3ugLijNioS1pqOTIolXNf67xxShYw4SQEmVXd3imiBG+U2bC2nVTySr/iRAA7Cjg=="
+  "resolved" "https://registry.npmjs.org/hast-util-select/-/hast-util-select-4.0.2.tgz"
+  "version" "4.0.2"
+  dependencies:
+    "bcp-47-match" "^1.0.0"
+    "comma-separated-tokens" "^1.0.0"
+    "css-selector-parser" "^1.0.0"
+    "direction" "^1.0.0"
+    "hast-util-has-property" "^1.0.0"
+    "hast-util-is-element" "^1.0.0"
+    "hast-util-to-string" "^1.0.0"
+    "hast-util-whitespace" "^1.0.0"
+    "not" "^0.1.0"
+    "nth-check" "^2.0.0"
+    "property-information" "^5.0.0"
+    "space-separated-tokens" "^1.0.0"
+    "unist-util-visit" "^2.0.0"
+    "zwitch" "^1.0.0"
+
 "hast-util-to-html@^7.1.1":
   "integrity" "sha512-Ujqj0hGuo3dIQKilkbauAv5teOqPvhaSLEgs1lgApFT0812e114KiffV8XfE4ttR8dRPqxNOIJOMu6SKOVOGlg=="
   "resolved" "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-7.1.1.tgz"
@@ -3364,6 +3389,11 @@
     "web-namespaces" "^1.0.0"
     "xtend" "^4.0.0"
     "zwitch" "^1.0.0"
+
+"hast-util-to-string@^1.0.0":
+  "integrity" "sha512-eK0MxRX47AV2eZ+Lyr18DCpQgodvaS3fAQO2+b9Two9F5HEoRPhiUMNzoXArMJfZi2yieFzUBMRl3HNJ3Jus3w=="
+  "resolved" "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-1.0.4.tgz"
+  "version" "1.0.4"
 
 "hast-util-to-text@^2.0.0":
   "integrity" "sha512-idXqFGmKInLKcFMbLvh0fldmV94o+aOdXL/z5H5XhPhUp/5vzycu7i15c8V9kC6W3XgGHg2uuiIcRJlWtESVfQ=="
@@ -7362,16 +7392,7 @@
   dependencies:
     "unist-util-visit-parents" "^2.0.0"
 
-"unist-util-visit@^2.0.0":
-  "integrity" "sha512-HoHNhGnKj6y+Sq+7ASo2zpVdfdRifhTgX2KTU3B/sO/TTlZchp7E3S4vjRzDJ7L60KmrCPsQkVK3lEF3cz36XQ=="
-  "resolved" "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.2.tgz"
-  "version" "2.0.2"
-  dependencies:
-    "@types/unist" "^2.0.0"
-    "unist-util-is" "^4.0.0"
-    "unist-util-visit-parents" "^3.0.0"
-
-"unist-util-visit@^2.0.3":
+"unist-util-visit@^2.0.0", "unist-util-visit@^2.0.3":
   "integrity" "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q=="
   "resolved" "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz"
   "version" "2.0.3"


### PR DESCRIPTION
#93 対応。

- `VFM` 関数の `math` オプション既定値を `false` から `true` に変更
- CLI オプション `--math` を `--disable-math` に変更して指定時に無効化
- `math: true` でも実際に数式が処理されなければ `<script>` と `<body>` 属性出力はしないように変更

@MurakamiShinyu 
`docs/vfm.md` と `tests/math.ts` についてレビューをお願いします。