### PR TITLE
chore: Fix a document of Raw HTML

### DIFF
--- a/docs/vfm.md
+++ b/docs/vfm.md
@@ -325,7 +325,9 @@ section.author {
 
 ```html
 <div class="custom">
-  <h1>Heading</h1>
+  <section id="heading" class="level1">
+    <h1>Heading</h1>
+  </section>
 </div>
 ```
 


### PR DESCRIPTION
Raw HTML のサンプル HTML で見出しの `<section>` が抜けていたので修正。