### PR TITLE
fix: Fixed to be empty string instead of null when only key is specified in Frontmatter YAML

### DIFF
--- a/docs/vfm.md
+++ b/docs/vfm.md
@@ -404,6 +404,8 @@ Frontmatter is a way of defining metadata in Markdown (file) units. Write YAML a
 
 I'm using [js-yaml](https://www.npmjs.com/package/js-yaml) for parse in YAML. Schema is [JSON_SCHEMA](https://yaml.org/spec/1.2/spec.html#id2803231). 
 
+The js-yaml parse makes `key:` to `key: null`. However, VFM treats this as an empty string. If `key:` or `key:""` is specified as the property of the attribute value, it is output as `key=""`. 
+
 **VFM**
 
 ```yaml

--- a/src/plugins/document.ts
+++ b/src/plugins/document.ts
@@ -36,8 +36,8 @@ const createHead = (data: Metadata, vfile: VFile) => {
 
   // <title>...</title>
   {
-    const title = data.title || vfile.stem;
-    if (title) {
+    const title = typeof data.title === 'string' ? data.title : vfile.stem;
+    if (typeof title === 'string') {
       head.push({ type: 'text', value: '\n' }, h('title', [title]));
     }
   }
@@ -122,19 +122,19 @@ const createBody = (data: Metadata, tree: Node) => {
 const createHTML = (data: Metadata, tree: Node, vfile: VFile) => {
   const props = createProperties(data.html);
 
-  if (data.id) {
+  if (typeof data.id === 'string') {
     props.id = data.id;
   }
 
-  if (data.lang) {
+  if (typeof data.lang === 'string') {
     props.lang = data.lang;
   }
 
-  if (data.dir) {
+  if (typeof data.dir === 'string') {
     props.dir = data.dir;
   }
 
-  if (data.class) {
+  if (typeof data.class === 'string') {
     props.class = data.class;
   }
 

--- a/src/plugins/metadata.ts
+++ b/src/plugins/metadata.ts
@@ -157,6 +157,16 @@ const parseMarkdown = (md: string): KeyValue => {
 };
 
 /**
+ * Read the string or null value in the YAML parse result.
+ * If the value is null, it will be an empty string
+ * @param value Value of YAML parse result.
+ * @returns String.
+ */
+const readStringOrNullValue = (value: string | null) => {
+  return value === null ? '' : `${value}`;
+};
+
+/**
  * Read an attributes from data object.
  * @param data Data object.
  * @returns Attributes of HTML tag.
@@ -168,7 +178,7 @@ const readAttributes = (data: any): Array<Attribute> | undefined => {
 
   const result: Array<Attribute> = [];
   for (const key of Object.keys(data)) {
-    result.push({ name: key, value: `${data[key]}` });
+    result.push({ name: key, value: readStringOrNullValue(data[key]) });
   }
 
   return result;
@@ -231,7 +241,7 @@ export const readMetadata = (md: string): Metadata => {
       case 'dir':
       case 'class':
       case 'title':
-        metadata[key] = `${data[key]}`;
+        metadata[key] = readStringOrNullValue(data[key]);
         break;
 
       case 'html':
@@ -258,7 +268,7 @@ export const readMetadata = (md: string): Metadata => {
       default:
         others.push([
           { name: 'name', value: key },
-          { name: 'content', value: `${data[key]}` },
+          { name: 'content', value: readStringOrNullValue(data[key]) },
         ]);
         break;
     }

--- a/src/plugins/metadata.ts
+++ b/src/plugins/metadata.ts
@@ -66,7 +66,10 @@ export type Metadata = {
   head?: string;
 };
 
-/** Key/Value pair. */
+/**
+ * Key/Value pair.
+ * Definition to enable subscript access of `Object`.
+ */
 type KeyValue = { [key: string]: any };
 
 /**
@@ -81,7 +84,7 @@ interface MetadataVFile extends VFile {
  * @param tree Tree of Markdown AST.
  * @returns Title text or `undefined`.
  */
-const readTitleFromHeading = (tree: Node) => {
+const readTitleFromHeading = (tree: Node): string | undefined => {
   const heading = select('heading', tree) as Element | undefined;
   if (!heading) {
     return;
@@ -160,9 +163,9 @@ const parseMarkdown = (md: string): KeyValue => {
  * Read the string or null value in the YAML parse result.
  * If the value is null, it will be an empty string
  * @param value Value of YAML parse result.
- * @returns String.
+ * @returns Text.
  */
-const readStringOrNullValue = (value: string | null) => {
+const readStringOrNullValue = (value: string | null): string => {
   return value === null ? '' : `${value}`;
 };
 
@@ -172,7 +175,7 @@ const readStringOrNullValue = (value: string | null) => {
  * @returns Attributes of HTML tag.
  */
 const readAttributes = (data: any): Array<Attribute> | undefined => {
-  if (typeof data !== 'object') {
+  if (data === null || typeof data !== 'object') {
     return;
   }
 

--- a/src/plugins/metadata.ts
+++ b/src/plugins/metadata.ts
@@ -216,7 +216,7 @@ const readAttributesCollection = (
  * @returns Settings.
  */
 const readSettings = (data: any): VFMSettings => {
-  if (typeof data !== 'object') {
+  if (data === null || typeof data !== 'object') {
     return { toc: false };
   }
 

--- a/tests/metadata.test.ts
+++ b/tests/metadata.test.ts
@@ -273,10 +273,10 @@ Text
 
 it('Specify null or empty string for Object', () => {
   const md = `---
-html:
+html: ''
 meta:
   -
-vfm: ''
+vfm:
 ---
 `;
   const received = stringify(md);

--- a/tests/metadata.test.ts
+++ b/tests/metadata.test.ts
@@ -207,6 +207,70 @@ Text
   expect(received).toBe(expected);
 });
 
+it('If the value is null or empty string, it will be an empty string', () => {
+  const md = `---
+id:
+lang:
+dir: ""
+class:
+title: ""
+html:
+  data-color-mode:
+  data-light-theme:
+  data-dark-theme:
+body:
+  id:
+  class:
+base:
+  target:
+  href:
+meta:
+  - name:
+    media:
+    content:
+  - name:
+    media:
+    content:
+link:
+  - rel:
+    href:
+  - rel:
+    href:
+script:
+  - type:
+    src:
+  - type:
+    src:
+author:
+---
+
+Text
+  `;
+
+  const received = stringify(md);
+  const expected = `<!doctype html>
+<html data-color-mode="" data-light-theme="" data-dark-theme="" id="" lang="" dir="" class="">
+  <head>
+    <meta charset="utf-8">
+    <title></title>
+    <base target="" href="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="" media="" content="">
+    <meta name="" media="" content="">
+    <meta name="author" content="">
+    <link rel="" href="">
+    <link rel="" href="">
+    <script type="" src=""></script>
+    <script type="" src=""></script>
+  </head>
+  <body id="" class="">
+    <p>Text</p>
+  </body>
+</html>
+`;
+  expect(received).toBe(expected);
+});
+
 it('Style from options', () => {
   const md = `---
 link:

--- a/tests/metadata.test.ts
+++ b/tests/metadata.test.ts
@@ -271,6 +271,27 @@ Text
   expect(received).toBe(expected);
 });
 
+it('Specify null or empty string for Object', () => {
+  const md = `---
+html:
+meta:
+  -
+vfm: ''
+---
+`;
+  const received = stringify(md);
+  const expected = `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body></body>
+</html>
+`;
+  expect(received).toBe(expected);
+});
+
 it('Style from options', () => {
   const md = `---
 link:


### PR DESCRIPTION
#111 修正。

@MurakamiShinyu 
レビューをお願いします。https://github.com/vivliostyle/vfm/issues/111#issuecomment-871301117 のとおり key のみ指定を空文字として扱い、またこれまで空文字で書き込みをスキップしていた `id` や `title` なども属性値や要素の値を空文字として出力するようにしました。