### PR TITLE
feat: Added VFM settings to Frontmatter

### DIFF
--- a/docs/vfm.md
+++ b/docs/vfm.md
@@ -445,6 +445,9 @@ script:
 vfm:
   math: false
   theme: 'theme.css'
+  partial: false
+  hardLineBreaks: false
+  disableFormatHtml: false
 author: 'Author'
 ---
 
@@ -506,10 +509,13 @@ author: 'Author'
 
 **vfm**
 
-|Property|Type|Description|
-|---|---|---|
-|`math`|Boolean|Enable math syntax, default 'true'.|
-|`theme`|String|Vivliostyle theme package or bare CSS file.|
+| Property            | Type      | Default | Description |
+| ------------------: | :-------: | :-----: | --- |
+| `math`              | `Boolean` | `true`  | Enable math syntax. |
+| `partial`           | `Boolean` | `false` | Output markdown fragments. |
+| `hardLineBreaks`    | `Boolean` | `false` | Add `<br>` at the position of hard line breaks, without needing spaces. |
+| `disableFormatHtml` | `Boolean` | `false` | Disable automatic HTML format. |
+| `theme`             | `String`  | -       | Vivliostyle theme package or bare CSS file. |
 
 ### Priority with options
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export * from './plugins/metadata';
 export interface StringifyMarkdownOptions {
   /** Custom stylesheet path/URL. */
   style?: string | string[];
-  /** Output markdown fragments.  */
+  /** Output markdown fragments. */
   partial?: boolean;
   /** Document title (ignored in partial mode). */
   title?: string;
@@ -95,8 +95,21 @@ export function VFM(
   metadata: Metadata = {},
 ): Processor {
   checkMetadata(metadata, { style, title, language });
-  if (metadata.vfm && metadata.vfm.math !== undefined) {
-    math = metadata.vfm.math;
+
+  // Prioritize metadata `vfm` settings over options
+  if (metadata.vfm) {
+    if (metadata.vfm.math !== undefined) {
+      math = metadata.vfm.math;
+    }
+    if (metadata.vfm.partial !== undefined) {
+      partial = metadata.vfm.partial;
+    }
+    if (metadata.vfm.hardLineBreaks !== undefined) {
+      hardLineBreaks = metadata.vfm.hardLineBreaks;
+    }
+    if (metadata.vfm.disableFormatHtml !== undefined) {
+      disableFormatHtml = metadata.vfm.disableFormatHtml;
+    }
   }
 
   const processor = unified()

--- a/src/plugins/metadata.ts
+++ b/src/plugins/metadata.ts
@@ -25,10 +25,16 @@ export type Attribute = {
 export type VFMSettings = {
   /** Enable math syntax. */
   math?: boolean;
+  /** Output markdown fragments.  */
+  partial?: boolean;
+  /** Add `<br>` at the position of hard line breaks, without needing spaces. */
+  hardLineBreaks?: boolean;
+  /** Disable automatic HTML format. */
+  disableFormatHtml?: boolean;
   /** Path of theme. */
   theme?: string;
   /** Enable TOC mode. */
-  toc: boolean;
+  toc?: boolean;
 };
 
 /** Metadata from Frontmatter. */
@@ -222,6 +228,15 @@ const readSettings = (data: any): VFMSettings => {
 
   return {
     math: typeof data.math === 'boolean' ? data.math : undefined,
+    partial: typeof data.partial === 'boolean' ? data.partial : undefined,
+    hardLineBreaks:
+      typeof data.hardLineBreaks === 'boolean'
+        ? data.hardLineBreaks
+        : undefined,
+    disableFormatHtml:
+      typeof data.disableFormatHtml === 'boolean'
+        ? data.disableFormatHtml
+        : undefined,
     theme: typeof data.theme === 'string' ? data.theme : undefined,
     toc: typeof data.toc === 'boolean' ? data.toc : false,
   };

--- a/tests/metadata.test.ts
+++ b/tests/metadata.test.ts
@@ -38,6 +38,9 @@ script:
     src: 'sample2.js'
 vfm:
   math: false
+  partial: true
+  hardLineBreaks: true
+  disableFormatHtml: true
   theme: 'theme.css'
 author: 'Author'
 other-meta1: 'other1'
@@ -111,6 +114,9 @@ other-meta2: 'other2'
     ],
     vfm: {
       math: false,
+      partial: true,
+      hardLineBreaks: true,
+      disableFormatHtml: true,
       toc: false,
       theme: 'theme.css',
     },
@@ -410,6 +416,68 @@ head: |
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
   <body></body>
+</html>
+`;
+  expect(received).toBe(expected);
+});
+
+it('vfm.partial: true', () => {
+  const md = `---
+vfm:
+  partial: true
+---
+
+Text
+`;
+  const received = stringify(md, { partial: false });
+  const expected = `
+<p>Text</p>
+`;
+  expect(received).toBe(expected);
+});
+
+it('vfm.hardLineBreaks: true', () => {
+  const md = `---
+vfm:
+  hardLineBreaks: true
+---
+
+Text
+Text
+`;
+  const received = stringify(md, { hardLineBreaks: false });
+  const expected = `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body>
+    <p>Text<br>Text</p>
+  </body>
+</html>
+`;
+  expect(received).toBe(expected);
+});
+
+it('vfm.disableFormatHtml: true', () => {
+  const md = `---
+vfm:
+  disableFormatHtml: true
+---
+
+Text
+`;
+  const received = stringify(md, { disableFormatHtml: false });
+  const expected = `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+<p>Text</p>
+</body>
 </html>
 `;
   expect(received).toBe(expected);


### PR DESCRIPTION
#98 対応。VFM オプションのうち Frontmatter で被るものとコールバック関数を持つ `replace` を除いて残った以下を `vfm` に追加。

- `partial`
- `hardLineBreaks`
- `disableFormatHtml`

これらは既存の `math` と同じく CLI、`stringify`、`VFM` オプションに優先する。