### PR TITLE
fix: Fixed an issue where ruby couldn't escape pipe with a backslash

### DIFF
--- a/docs/vfm.md
+++ b/docs/vfm.md
@@ -12,6 +12,7 @@ Vivliostyle Flavored Markdown (VFM), a Markdown syntax optimized for book author
 - [Image](#image)
   - [with caption and single line](#with-caption-and-single-line)
 - [Ruby](#ruby)
+  - [Escape pipe in ruby body](#escape-pipe-in-ruby-body)
 - [Sectionization](#sectionization)
   - [Plain section](#plain-section)
 - [Raw HTML](#raw-html)
@@ -169,8 +170,6 @@ figure figcaption {
 
 ## Ruby
 
-<Badge type="warning">PRE-RELEASE</Badge>
-
 **VFM**
 
 ```
@@ -190,6 +189,22 @@ ruby {
 }
 ruby rt {
 }
+```
+
+### Escape pipe in ruby body
+
+If want to escape the delimiter pipe `|`, add `\` immediately before it.
+
+**VFM**
+
+```
+{a\|b|c}
+```
+
+**HTML**
+
+```html
+<p><ruby>a|b<rt>c</rt></ruby></p>
 ```
 
 ## Sectionization

--- a/src/plugins/ruby.ts
+++ b/src/plugins/ruby.ts
@@ -10,7 +10,6 @@ function locateRuby(value: string, fromIndex: number) {
 
 const tokenizer: Tokenizer = function (eat, value, silent) {
   const now = eat.now();
-  ///const match = /^{(.+?)\|(.+?)}/.exec(value);
   const match = /^{(.+?)(?<=[^\\|])\|(.+?)}/.exec(value);
   if (!match) return;
 

--- a/src/plugins/ruby.ts
+++ b/src/plugins/ruby.ts
@@ -10,7 +10,8 @@ function locateRuby(value: string, fromIndex: number) {
 
 const tokenizer: Tokenizer = function (eat, value, silent) {
   const now = eat.now();
-  const match = /^{(.+?)\|(.+?)}/.exec(value);
+  ///const match = /^{(.+?)\|(.+?)}/.exec(value);
+  const match = /^{(.+?)(?<=[^\\|])\|(.+?)}/.exec(value);
   if (!match) return;
 
   const [eaten, inlineContent, rubyText] = match;

--- a/tests/ruby.test.ts
+++ b/tests/ruby.test.ts
@@ -1,79 +1,36 @@
-import { stripIndent } from 'common-tags';
-import { buildProcessorTestingCode } from './utils';
+import { stringify } from '../src/index';
 
-it(
-  'simple ruby',
-  buildProcessorTestingCode(
-    `{a|b}`,
-    stripIndent`
-    root[1]
-    └─0 paragraph[1]
-        └─0 ruby[1]
-            │ data: {"hName":"ruby","rubyText":"b"}
-            └─0 text "a"
-    `,
-    `<p><ruby>a<rt>b</rt></ruby></p>`,
-  ),
-);
+const options = {
+  partial: true,
+  disableFormatHtml: true,
+};
 
-it(
-  'enables escape in ruby body',
-  buildProcessorTestingCode(
-    `{a\\|b|c}`,
-    stripIndent`
-    root[1]
-    └─0 paragraph[1]
-        └─0 ruby[1]
-            │ data: {"hName":"ruby","rubyText":"b|c"}
-            └─0 text "a\\\\"
-    `,
-    `<p><ruby>a\\<rt>b|c</rt></ruby></p>`,
-  ),
-);
+it('Simple ruby', () => {
+  const received = stringify(`{a|b}`, options);
+  const expected = `<p><ruby>a<rt>b</rt></ruby></p>`;
+  expect(received).toBe(expected);
+});
 
-it(
-  'disables any inline rule in <rt>',
-  buildProcessorTestingCode(
-    `{a|*b*}`,
-    stripIndent`
-    root[1]
-    └─0 paragraph[1]
-        └─0 ruby[1]
-            │ data: {"hName":"ruby","rubyText":"*b*"}
-            └─0 text "a"
-    `,
-    `<p><ruby>a<rt>*b*</rt></ruby></p>`,
-  ),
-);
+it('Enables escape in ruby body', () => {
+  const received = stringify(`{a\\|b|c}`, options);
+  const expected = `<p><ruby>a|b<rt>c</rt></ruby></p>`;
+  expect(received).toBe(expected);
+});
 
-it(
-  'nested ruby',
-  buildProcessorTestingCode(
-    `{{a|b}|c}`,
-    stripIndent`
-    root[1]
-    └─0 paragraph[2]
-        ├─0 ruby[1]
-        │   │ data: {"hName":"ruby","rubyText":"b"}
-        │   └─0 text "{a"
-        └─1 text "|c}"
-    `,
-    `<p><ruby>{a<rt>b</rt></ruby>|c}</p>`,
-  ),
-);
+it('Disables any inline rule in <rt>', () => {
+  const received = stringify(`{a|*b*}`, options);
+  const expected = `<p><ruby>a<rt>*b*</rt></ruby></p>`;
+  expect(received).toBe(expected);
+});
 
-it(
-  'ruby with newline',
-  buildProcessorTestingCode(
-    `{a\nb|c}`,
-    stripIndent`
-    root[1]
-    └─0 paragraph[3]
-        ├─0 text "{a"
-        ├─1 break
-        └─2 text "b|c}"
-    `,
-    `<p>{a<br>\nb|c}</p>`,
-    { hardLineBreaks: true },
-  ),
-);
+it('Nested ruby', () => {
+  const received = stringify(`{{a|b}|c}`, options);
+  const expected = `<p><ruby>{a<rt>b</rt></ruby>|c}</p>`;
+  expect(received).toBe(expected);
+});
+
+it('Ruby with newline', () => {
+  const received = stringify(`{a\nb|c}`, { ...options, hardLineBreaks: true });
+  const expected = `<p>{a<br>\nb|c}</p>`;
+  expect(received).toBe(expected);
+});


### PR DESCRIPTION
#32 対応。

@spring-raining 
レビューをお願いします。

`tests/ruby.test.ts` の "Enables escape in ruby body" が本件と対応するものとなります。想定通りか確認してください。

なおテストについて MDAST の検証をやめて HTML のみに変更していますが、これは将来の remark 更新で micromark 対応していないものの処理結果が反映されないことを見越しての対応です。他のテストも私が引き継いでからの新規追加分はそのようにしています。