### PR TITLE
feat: Merge the frontmatter's class properties

### DIFF
--- a/docs/vfm.md
+++ b/docs/vfm.md
@@ -13,8 +13,9 @@ VFM syntax and features are listed in ascending alphabetical (`A`-`Z`) order.
   - [with caption](#with-caption)
 - [Footnotes](#footnotes)
 - [Frontmatter](#frontmatter)
-  - [Reserved words](#reserved-words)
+  - [Reserved properties](#reserved-properties)
   - [Priority with options](#priority-with-options)
+  - [Merge class properties](#merge-class-properties)
 - [Hard new line (optional)](#hard-new-line)
 - [Image](#image)
   - [with caption and single line](#with-caption-and-single-line)
@@ -237,7 +238,7 @@ author: 'Author'
 | `id`     | `String`   | `<html id="...">` |
 | `lang`   | `String`   | `<html lang="...">` |
 | `dir`    | `String`   | `<html dir="...">`, value is `ltr`, `rtl` or `auto`. |
-| `class`  | `String`   | `<html class="...">` |
+| `class`  | `String`   | `<html class="...">` and `<body class="...">` |
 | `title`  | `String`   | `<title>...</title>`, if missing, very first heading of the content will be treated as title. |
 | `html`   | `Object`   | `<html key="value">`, key/value pair becomes attribute of `<html>`. |
 | `body`   | `Object`   | `<body key="value">`, key/value pair becomes attribute of `<body>`. |
@@ -267,7 +268,7 @@ If there are multiple specifications for the same purpose, the priority is as fo
 1. Frontmatter
 2. VFM options
 
-In Frontmatter, if there is a duplicate of the root `id` and` id` in the `html` property, the root definition takes precedence.
+In Frontmatter, if there is a duplicate of the root `id` and `id` in the `html` property, the root definition takes precedence.
 
 ```yaml
 ---
@@ -278,6 +279,35 @@ html:
 ```
 
 In this example, `sample1` is adopted.
+
+```html
+<html id="sample1">
+</html>
+```
+
+### Merge class properties
+
+The `class` properties of the root, `html`, and `body` are combined separated by spaces.
+
+```yaml
+---
+class: 'root'
+html:
+  class: 'html'
+body:
+  class: 'body sample'
+---
+```
+
+In this example, merged.
+
+```html
+<html class="root html">
+  <body class="root body sample">
+  </body>
+</html>
+```
+
 
 ## Hard new line
 

--- a/src/plugins/document.ts
+++ b/src/plugins/document.ts
@@ -90,11 +90,11 @@ const createHead = (data: Metadata, vfile: VFile) => {
 
 /**
  * Create Markdown AST for `<body>`.
- * @param data Metadata.
+ * @param metadata Metadata.
  * @param tree Tree of Markdown AST.
  * @returns AST of `<body>`.
  */
-const createBody = (data: Metadata, tree: Node) => {
+const createBody = (metadata: Metadata, tree: Node) => {
   // <body>...</body>
   const contents =
     tree.type === 'root' && Array.isArray(tree.children)
@@ -106,7 +106,15 @@ const createBody = (data: Metadata, tree: Node) => {
 
   contents.push({ type: 'text', value: '\n' });
 
-  const props = createProperties(data.body);
+  const props = createProperties(metadata.body);
+
+  // <body class="root-class body-class1 body-class2 ...">
+  if (typeof metadata.class === 'string') {
+    props.class = props.class
+      ? `${metadata.class} ${props.class}`
+      : metadata.class;
+  }
+
   return h('body', props, contents);
 };
 
@@ -114,35 +122,38 @@ const createBody = (data: Metadata, tree: Node) => {
  * Create properties for `<html>`.
  * Sets the value defined for `html` in Frontmatter.
  * However, if `id`,` lang`, `dir`, and `class` are defined in the root, those are given priority.
- * @param data Metadata.
+ * @param metadata Metadata.
  * @param tree Tree of Markdown AST.
  * @param vfile VFile.
  * @returns AST of `<html>`.
  */
-const createHTML = (data: Metadata, tree: Node, vfile: VFile) => {
-  const props = createProperties(data.html);
+const createHTML = (metadata: Metadata, tree: Node, vfile: VFile) => {
+  const props = createProperties(metadata.html);
 
-  if (typeof data.id === 'string') {
-    props.id = data.id;
+  if (typeof metadata.id === 'string') {
+    props.id = metadata.id;
   }
 
-  if (typeof data.lang === 'string') {
-    props.lang = data.lang;
+  if (typeof metadata.lang === 'string') {
+    props.lang = metadata.lang;
   }
 
-  if (typeof data.dir === 'string') {
-    props.dir = data.dir;
+  if (typeof metadata.dir === 'string') {
+    props.dir = metadata.dir;
   }
 
-  if (typeof data.class === 'string') {
-    props.class = data.class;
+  // <html class="root-class html-class1 html-class2 ...">
+  if (typeof metadata.class === 'string') {
+    props.class = props.class
+      ? `${metadata.class} ${props.class}`
+      : metadata.class;
   }
 
   return h('html', props, [
     { type: 'text', value: '\n' },
-    h('head', createHead(data, vfile)),
+    h('head', createHead(metadata, vfile)),
     { type: 'text', value: '\n' },
-    createBody(data, tree),
+    createBody(metadata, tree),
     { type: 'text', value: '\n' },
   ]);
 };

--- a/tests/metadata.test.ts
+++ b/tests/metadata.test.ts
@@ -205,7 +205,7 @@ Text
     <script type="text/javascript" src="sample1.js"></script>
     <script type="text/javascript" src="sample2.js"></script>
   </head>
-  <body id="body" class="foo bar">
+  <body id="body" class="my-class foo bar">
     <p>Text</p>
   </body>
 </html>
@@ -478,6 +478,28 @@ Text
 <body>
 <p>Text</p>
 </body>
+</html>
+`;
+  expect(received).toBe(expected);
+});
+
+it('Merge `class` properties', () => {
+  const md = `---
+class: "root"
+html:
+  class: "html"
+body:
+  class: "foo bar"
+---
+`;
+  const received = stringify(md, { disableFormatHtml: false });
+  const expected = `<!doctype html>
+<html class="root html">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body class="root foo bar"></body>
 </html>
 `;
   expect(received).toBe(expected);


### PR DESCRIPTION
#119 対応。

@MurakamiShinyu 
提案どおり Frontmatter におけるルートの `class` は `html` と `body` のそれらを上書きするのではなく、スペース区切りで結合されるように実装しました。

この変更にともない仕様書にも解説を追加しています。また仕様書の改訂で目次のリンク間違いも修正しました。

`metadata.test.ts` 末尾に追加した本件のテスト コードと `vfm.md` の新規項目 "Merge class properties" についてレビューをお願いします。

