### PR TITLE
chore: Added script to dry-run release-it

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "dev": "tsc -w",
     "prepublishOnly": "yarn build",
     "release": "release-it",
+    "release:dry": "release-it --dry-run",
     "release:pre": "release-it --preRelease --npm.tag=latest",
     "test": "jest",
     "test:debug": "jest tests/xxx.test.ts --silent=false --verbose false"


### PR DESCRIPTION
正式リリースのための準備。

release-it を dry-run モードで実行するためのスクリプトを追加。Git のコミット候補が残っているとエラーになるので注意。