### PR TITLE
docs: Deleted "Working Draft" from VFM reference

### DIFF
--- a/docs/vfm.md
+++ b/docs/vfm.md
@@ -1,4 +1,4 @@
-# Vivliostyle Flavored Markdown: Working Draft
+# Vivliostyle Flavored Markdown
 
 Vivliostyle Flavored Markdown (VFM), a Markdown syntax optimized for book authoring. It is standardized and published for Vivliostyle and its sibling projects. VFM is implemented top on [CommonMark](https://commonmark.org/) and [GitHub Flavored Markdown (GFM)](https://github.github.com/gfm/).
 


### PR DESCRIPTION
Since VFM v1.0 was released, the basic specifications were fixed. Therefore, the notation "Working Draft" is no longer necessary.

refs #122