### PR TITLE
feat: Supports metadata specification for stringify

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Vivliostyle Flavored Markdown (VFM), a Markdown syntax optimized for book author
     - [Unified processor](#unified-processor)
     - [Unified plugin](#unified-plugin)
     - [readMetadata](#readmetadata)
+- [User-specified metadata](#user-specified-metadata)
 - [Spec](#spec)
   - [Principles](#principles)
   - [Links](#links)
@@ -382,6 +383,41 @@ console.log(metadata);
 ```
 
 About `Metadata`, refer to [VFM](https://vivliostyle.github.io/vfm/#/vfm)'s "Frontmatter" or type information of TypeScript.
+
+## User-specified metadata
+
+Metadata can be specified for `stringify`, this specification takes precedence over Frontmatter. 
+
+The following usage is assumed.
+
+- Use metadata other than Frontmatter
+- Process Frontmatter metadata obtained by `readMetadata` 
+
+```js
+stringify(
+  '# Title',
+  {},
+  { title: 'My Page', body: [{ name: 'id', value: 'page' }] },
+);
+```
+
+HTML:
+
+```html
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>My Page</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body id="page">
+    <section id="title" class="level1">
+      <h1>Title</h1>
+    </section>
+  </body>
+</html>
+```
 
 ## Spec
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,8 +149,9 @@ export function VFM(
 export function stringify(
   markdownString: string,
   options: StringifyMarkdownOptions = {},
+  metadata: Metadata = readMetadata(markdownString),
 ): string {
-  const processor = VFM(options, readMetadata(markdownString));
+  const processor = VFM(options, metadata);
   const vfile = processor.processSync(markdownString);
   debug(vfile.data);
   return String(vfile);

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,4 +1,4 @@
-import * as lib from '../src';
+import { stringify } from '../src';
 import { ReplaceRule } from '../src/plugins/replace';
 
 it('replace', () => {
@@ -16,7 +16,7 @@ it('replace', () => {
     },
   ] as ReplaceRule[];
   expect(
-    lib.stringify(
+    stringify(
       `
 [icon1][Notice]
 
@@ -35,7 +35,7 @@ it('replace', () => {
 it('empty replace', () => {
   const rules = [] as ReplaceRule[];
   expect(
-    lib.stringify(
+    stringify(
       `
 [icon1][Notice]
 
@@ -51,7 +51,7 @@ it('empty replace', () => {
 });
 
 it('<pre>', () => {
-  const actual = lib.stringify(`<pre>\n*    *    *\n   *    *    *\n</pre>`, {
+  const actual = stringify(`<pre>\n*    *    *\n   *    *    *\n</pre>`, {
     partial: true,
     disableFormatHtml: true,
   });
@@ -64,7 +64,7 @@ it('<pre>', () => {
 });
 
 it('Raw HTML', () => {
-  const actual = lib.stringify(
+  const actual = stringify(
     `<div class="custom">
   <p>Hey</p>
 </div>`,
@@ -81,7 +81,7 @@ it('Raw HTML', () => {
 });
 
 it('Raw HTML with Markdown', () => {
-  const actual = lib.stringify(
+  const actual = stringify(
     `<div class="custom">
 
 # Heading
@@ -97,6 +97,29 @@ it('Raw HTML with Markdown', () => {
     <h1>Heading</h1>
   </section>
 </div>
+`;
+  expect(actual).toBe(expected);
+});
+
+it('User-specified metadata (without Frontmatter)', () => {
+  const actual = stringify(
+    '# Title',
+    {},
+    { title: 'My Page', body: [{ name: 'id', value: 'page' }] },
+  );
+  const expected = `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>My Page</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body id="page">
+    <section id="title" class="level1">
+      <h1>Title</h1>
+    </section>
+  </body>
+</html>
 `;
   expect(actual).toBe(expected);
 });


### PR DESCRIPTION
refs: #130

`stringify` にメタデータ指定可能とした。`VFM` 関数と異なり既定値は Frontmatter を読み込んだものとする。以下の用途を想定。

- Markdown に Frontmatter を定義せずメタデータを指定可能
- Markdown の Frontmatter を `readMetadata` で読み込み加工したものを指定
  - Web サイト用 HTML でサイト全体とページ単位 (Markdown) のタイトルを合成するなど
  - `Page | Site` のような感じで
