### PR TITLE
fix: Type error of object property

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -108,7 +108,7 @@ function main(
     });
   } catch (err) {
     // eslint-disable-next-line no-console
-    console.log(err.message);
+    console.log(err);
   }
 }
 


### PR DESCRIPTION
There is no need to refer to the `message` property of Error because `console.error` will automatically try to stringify it.