### PR TITLE
docs: Change DESIGN.md link to docs link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,137 +1,134 @@
 <!DOCTYPE html>
 <html>
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <title>Vivliostyle Flavored Markdown</title>
+    <!-- <link rel="icon" href="images/vivliostyle-icon.png" /> -->
+    <link rel="stylesheet" href="https://unpkg.com/docute@4/dist/docute.css" />
+  </head>
 
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>Vivliostyle Flavored Markdown</title>
-  <!-- <link rel="icon" href="images/vivliostyle-icon.png" /> -->
-  <link rel="stylesheet" href="https://unpkg.com/docute@4/dist/docute.css" />
-</head>
+  <body>
+    <div id="docute"></div>
+    <script src="https://unpkg.com/docute@4/dist/docute.js"></script>
+    <script>
+      if (location.hash.indexOf('%23')) {
+        // fix %-encoded '#' in hash
+        location.hash = location.hash.replace('%23', '#');
+      }
 
-<body>
-  <div id="docute"></div>
-  <script src="https://unpkg.com/docute@4/dist/docute.js"></script>
-  <script>
-    if (location.hash.indexOf('%23')) {
-      // fix %-encoded '#' in hash
-      location.hash = location.hash.replace('%23', '#');
-    }
-
-    new Docute({
-      title: 'VFM: Vivliostyle Flavored Markdown',
-      target: '#docute',
-      plugins: [],
-      nav: [
-        {
-          title: 'Home',
-          link: '/',
+      new Docute({
+        title: 'VFM: Vivliostyle Flavored Markdown',
+        target: '#docute',
+        plugins: [],
+        nav: [
+          {
+            title: 'Home',
+            link: '/',
+          },
+          {
+            title: 'Vivliostyle',
+            link: 'https://vivliostyle.org',
+          },
+          {
+            title: 'GitHub',
+            link: 'https://github.com/vivliostyle/vfm',
+          },
+        ],
+        sidebar: [
+          {
+            title: 'Spec',
+            children: [
+              { title: 'VFM', link: '/vfm' },
+              { title: 'Hooks', link: '/hooks' },
+              {
+                title: 'Theme Design Guideline',
+                link: 'https://github.com/vivliostyle/themes/tree/master/DESIGN.md',
+              },
+            ],
+          },
+          {
+            title: 'Community',
+            children: [
+              {
+                title: 'GitHub',
+                link: 'https://github.com/vivliostyle',
+              },
+              {
+                title: 'Twitter',
+                link: 'https://twitter.com/vivliostyle',
+              },
+              {
+                title: 'Slack',
+                link: 'https://join.slack.com/t/vivliostyle/shared_invite/enQtNzc1NjE4ODk1ODI5LWQxZjM4YTZjMmQ0ZTUyNmUyOGZlMzIwZjQ5OWYwYjkyZDZmOTIwNGMwOWU5NDc0NjE5OTAyMmVhZTRhYTAyNWQ',
+              },
+            ],
+          },
+        ],
+        overrides: {
+          '/': {
+            language: 'English',
+          },
+          '/ja/': {
+            language: 'Japanese',
+            nav: [
+              {
+                title: 'ホーム',
+                link: '/ja/',
+              },
+              {
+                nav: [
+                  {
+                    title: 'Home',
+                    link: '/',
+                  },
+                  {
+                    title: 'Vivliostyle',
+                    link: 'https://vivliostyle.org',
+                  },
+                  {
+                    title: 'GitHub',
+                    link: 'https://github.com/vivliostyle/vfm',
+                  },
+                ],
+                sidebar: [
+                  {
+                    title: 'Spec',
+                    children: [
+                      { title: 'VFM', link: '/vfm' },
+                      { title: 'Hooks', link: '/hooks' },
+                      {
+                        title: 'Theme Spec',
+                        link: 'https://vivliostyle.github.io/themes/#/spec',
+                      },
+                    ],
+                  },
+                  {
+                    title: 'Community',
+                    children: [
+                      {
+                        title: 'GitHub',
+                        link: 'https://github.com/vivliostyle',
+                      },
+                      {
+                        title: 'Twitter',
+                        link: 'https://twitter.com/vivliostyle',
+                      },
+                      {
+                        title: 'Slack',
+                        link: 'https://join.slack.com/t/vivliostyle/shared_invite/enQtNzc1NjE4ODk1ODI5LWQxZjM4YTZjMmQ0ZTUyNmUyOGZlMzIwZjQ5OWYwYjkyZDZmOTIwNGMwOWU5NDc0NjE5OTAyMmVhZTRhYTAyNWQ',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
         },
-        {
-          title: 'Vivliostyle',
-          link: 'https://vivliostyle.org',
-        },
-        {
-          title: 'GitHub',
-          link: 'https://github.com/vivliostyle/vfm',
-        },
-      ],
-      sidebar: [
-        {
-          title: 'Spec',
-          children: [
-            { title: 'VFM', link: '/vfm' },
-            { title: 'Hooks', link: '/hooks' },
-            {
-              title: 'Theme Design Guideline',
-              link:
-                'https://github.com/vivliostyle/themes/tree/master/DESIGN.md',
-            },
-          ],
-        },
-        {
-          title: 'Community',
-          children: [
-            {
-              title: 'GitHub',
-              link: 'https://github.com/vivliostyle',
-            },
-            {
-              title: 'Twitter',
-              link: 'https://twitter.com/vivliostyle',
-            },
-            {
-              title: 'Slack',
-              link:
-                'https://join.slack.com/t/vivliostyle/shared_invite/enQtNzc1NjE4ODk1ODI5LWQxZjM4YTZjMmQ0ZTUyNmUyOGZlMzIwZjQ5OWYwYjkyZDZmOTIwNGMwOWU5NDc0NjE5OTAyMmVhZTRhYTAyNWQ',
-            },
-          ],
-        },
-      ],
-      overrides: {
-        '/': {
-          language: 'English',
-        },
-        '/ja/': {
-          language: 'Japanese',
-          nav: [
-            {
-              title: 'ホーム',
-              link: '/ja/',
-            },
-            {
-              nav: [
-                {
-                  title: 'Home',
-                  link: '/',
-                },
-                {
-                  title: 'Vivliostyle',
-                  link: 'https://vivliostyle.org',
-                },
-                {
-                  title: 'GitHub',
-                  link: 'https://github.com/vivliostyle/vfm',
-                },
-              ],
-              sidebar: [
-                {
-                  title: 'Spec',
-                  children: [
-                    { title: 'VFM', link: '/vfm' },
-                    { title: 'Hooks', link: '/hooks' },
-                    {
-                      title: 'Theme Design Guideline',
-                      link:
-                        'https://github.com/vivliostyle/themes/tree/master/DESIGN.md',
-                    },
-                  ],
-                },
-                {
-                  title: 'Community',
-                  children: [
-                    {
-                      title: 'GitHub',
-                      link: 'https://github.com/vivliostyle',
-                    },
-                    {
-                      title: 'Twitter',
-                      link: 'https://twitter.com/vivliostyle',
-                    },
-                    {
-                      title: 'Slack',
-                      link:
-                        'https://join.slack.com/t/vivliostyle/shared_invite/enQtNzc1NjE4ODk1ODI5LWQxZjM4YTZjMmQ0ZTUyNmUyOGZlMzIwZjQ5OWYwYjkyZDZmOTIwNGMwOWU5NDc0NjE5OTAyMmVhZTRhYTAyNWQ',
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      },
-    });
-  </script>
-</body>
-
+      });
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
And HTML formatted by prettier.

VFM 仕様ページのサイドバーでテーマ ガイドラインがリンク切れになってた原因を調べたところ、Themes で以下のリンク変更があったことに気づいたのでこちらにも反映。

- [docs: change DESIGN.md link to docs link · vivliostyle/themes@ae331bc](https://github.com/vivliostyle/themes/commit/ae331bcc2f4b02941f1fadec4f14e35286d8864c)