### PR TITLE
docs: Change DESIGN.md link to docs link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -45,8 +45,8 @@
               { title: 'VFM', link: '/vfm' },
               { title: 'Hooks', link: '/hooks' },
               {
-                title: 'Theme Design Guideline',
-                link: 'https://github.com/vivliostyle/themes/tree/master/DESIGN.md',
+                title: 'Theme Spec',
+                link: 'https://vivliostyle.github.io/themes/#/spec',
               },
             ],
           },


### PR DESCRIPTION
`index.html` の `overrides` 側しか更新していなかったので `sidebar` もリンクを変更。