### PR TITLE
fix: remove heading attributes notation on page title

### DIFF
--- a/src/plugins/metadata.ts
+++ b/src/plugins/metadata.ts
@@ -11,6 +11,7 @@ import { Node } from 'unist';
 import { select } from 'unist-util-select';
 import visit from 'unist-util-visit';
 import { VFile } from 'vfile';
+import { mdast as attr } from './attr';
 import { mdast as footnotes } from './footnotes';
 
 /** Attribute of HTML tag. */
@@ -164,6 +165,7 @@ const parseMarkdown = (md: string): KeyValue => {
       [markdown, { gfm: true, commonmark: true }],
       // Remove footnotes when reading title from heading
       footnotes,
+      attr,
       frontmatter,
       mdast,
     ] as unified.PluggableList<unified.Settings>)


### PR DESCRIPTION
This PR will fix #134 issue

**Before**
```bash
$ echo "# Foo {.foo}" | vfm
<!doctype html>
<html>
  <head>
    <meta charset="utf-8">
    <title>Foo {.foo}</title>
    <meta name="viewport" content="width=device-width, initial-scale=1">
  </head>
  <body>
    <section class="level1 foo" id="foo">
      <h1 class="foo">Foo</h1>
    </section>
  </body>
</html>
```

**After**
```bash
$ echo "# Foo {.foo}" | vfm
<!doctype html>
<html>
  <head>
    <meta charset="utf-8">
    <title>Foo</title>
    <meta name="viewport" content="width=device-width, initial-scale=1">
  </head>
  <body>
    <section class="level1 foo" id="foo">
      <h1 class="foo">Foo</h1>
    </section>
  </body>
</html>
```

---

This issue also affecting generated toc in **vivliostyle-cli**.
**Generated toc before**
![image](https://user-images.githubusercontent.com/2143364/170828153-d06eb1d6-2b24-4c3f-a754-2d2ab5e77e71.png)

**Generated toc after**
![image](https://user-images.githubusercontent.com/2143364/170828184-b95dfd74-9b62-46f3-a42b-b5939deab052.png)


