### PR TITLE
chore: Added test to exclude attribute syntax in title heading

### DIFF
--- a/tests/metadata.test.ts
+++ b/tests/metadata.test.ts
@@ -534,3 +534,12 @@ title: ["Foo", "Bar"]
   };
   expect(received).toStrictEqual(expected);
 });
+
+it('Exclude attribute syntax in title heading', () => {
+  const md = '# Foo {.bar}';
+  const received = readMetadata(md);
+  const expected: Metadata = {
+    title: 'Foo',
+  };
+  expect(received).toStrictEqual(expected);
+});


### PR DESCRIPTION
refs #148
↑の PR は私の手元でも動作を確認済みだが、ユニット テストを追加して動作を明示しておく。