### PR TITLE
docs: 日本語ドキュメントのサイドバーが壊れていたのを修正

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -80,48 +80,40 @@
                 link: '/ja/',
               },
               {
-                nav: [
+                title: 'Vivliostyle',
+                link: 'https://vivliostyle.org/ja/',
+              },
+              {
+                title: 'GitHub',
+                link: 'https://github.com/vivliostyle/vfm',
+              },
+            ],
+            sidebar: [
+              {
+                title: 'Spec',
+                children: [
+                  { title: 'VFM', link: '/ja/vfm' },
+                  { title: 'Hooks', link: '/ja/hooks' },
                   {
-                    title: 'Home',
-                    link: '/',
-                  },
-                  {
-                    title: 'Vivliostyle',
-                    link: 'https://vivliostyle.org',
-                  },
-                  {
-                    title: 'GitHub',
-                    link: 'https://github.com/vivliostyle/vfm',
+                    title: 'Theme Spec',
+                    link: 'https://vivliostyle.github.io/themes/#/ja/spec',
                   },
                 ],
-                sidebar: [
+              },
+              {
+                title: 'Community',
+                children: [
                   {
-                    title: 'Spec',
-                    children: [
-                      { title: 'VFM', link: '/vfm' },
-                      { title: 'Hooks', link: '/hooks' },
-                      {
-                        title: 'Theme Spec',
-                        link: 'https://vivliostyle.github.io/themes/#/spec',
-                      },
-                    ],
+                    title: 'GitHub',
+                    link: 'https://github.com/vivliostyle',
                   },
                   {
-                    title: 'Community',
-                    children: [
-                      {
-                        title: 'GitHub',
-                        link: 'https://github.com/vivliostyle',
-                      },
-                      {
-                        title: 'Twitter',
-                        link: 'https://twitter.com/vivliostyle',
-                      },
-                      {
-                        title: 'Slack',
-                        link: 'https://join.slack.com/t/vivliostyle/shared_invite/enQtNzc1NjE4ODk1ODI5LWQxZjM4YTZjMmQ0ZTUyNmUyOGZlMzIwZjQ5OWYwYjkyZDZmOTIwNGMwOWU5NDc0NjE5OTAyMmVhZTRhYTAyNWQ',
-                      },
-                    ],
+                    title: 'Twitter',
+                    link: 'https://twitter.com/vivliostyle',
+                  },
+                  {
+                    title: 'Slack',
+                    link: 'https://join.slack.com/t/vivliostyle/shared_invite/enQtNzc1NjE4ODk1ODI5LWQxZjM4YTZjMmQ0ZTUyNmUyOGZlMzIwZjQ5OWYwYjkyZDZmOTIwNGMwOWU5NDc0NjE5OTAyMmVhZTRhYTAyNWQ',
                   },
                 ],
               },


### PR DESCRIPTION
日本語ドキュメントのサイドバーが壊れてたのに気がつき修正しました。

スクリーンショット
修正前
![Screenshot 2023-03-17 at 12 28 27](https://user-images.githubusercontent.com/3324737/225806081-928b36ba-b9ed-4eb1-858f-5bcc1aff9e86.png)

サイドバーの「Spec→VFM」をクリックしてもVFM仕様の日本語の目次が展開されることはなく、英語のVFM仕様のドキュメントに移動してしまいます。
また、右上の「ホーム」のリンクのところに「Vivliostyle」と「GitHub」のリンクもあるべきなのですが、それらがありません。


修正後
![Screenshot 2023-03-17 at 12 30 26](https://user-images.githubusercontent.com/3324737/225806106-5dbc2c0c-9d16-4bf1-b767-76791659983b.png)
