### PR TITLE
chore: [Breaking Change] Update support version of Node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Vivliostyle Foundation",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">= 12"
+    "node": ">= 16"
   },
   "main": "lib/index.js",
   "bin": {


### PR DESCRIPTION
Vivliostyle CLI の下限 Node.js バージョンが 16 なので、VFM も踏襲します。