### PR TITLE
feat: WAI-ARIA role

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "release:pre": "release-it --preRelease --npm.tag=latest",
     "test": "jest",
     "test:watch": "jest --runInBand --watch",
-    "test:debug": "jest tests/wai-aria-role.test.ts --silent=false --verbose false"
+    "test:debug": "jest tests/xxx.test.ts --silent=false --verbose false"
   },
   "dependencies": {
     "debug": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "release:pre": "release-it --preRelease --npm.tag=latest",
     "test": "jest",
     "test:watch": "jest --runInBand --watch",
-    "test:debug": "jest tests/xxx.test.ts --silent=false --verbose false"
+    "test:debug": "jest tests/wai-aria-role.test.ts --silent=false --verbose false"
   },
   "dependencies": {
     "debug": "^4.3.1",

--- a/src/plugins/wai-aria-role.ts
+++ b/src/plugins/wai-aria-role.ts
@@ -61,13 +61,16 @@ const visitor: Visitor<Element> = (node) => {
     return;
   }
 
+  // Skip if the role already exists.
+  if (node.properties.role) {
+    return;
+  }
+
+  // Set the first target class found to role.
   for (const className of node.properties.className) {
     if (typeof className === 'string' && targetClassNames.includes(className)) {
-      if (Array.isArray(node.properties.role)) {
-        node.properties.role.push(`doc-${className}`);
-      } else {
-        node.properties.role = [`doc-${className}`];
-      }
+      node.properties.role = `doc-${className}`;
+      break;
     }
   }
 };

--- a/src/plugins/wai-aria-role.ts
+++ b/src/plugins/wai-aria-role.ts
@@ -1,0 +1,81 @@
+import { Node } from 'unist';
+import visit from 'unist-util-visit';
+import { Element } from 'hast';
+import { Visitor } from 'unist-util-visit';
+
+/**
+ * Collection of class names to which DPUB-ARIA roles are to be added.
+ */
+const targetClassNames = [
+  'abstract',
+  'acknowledgments',
+  'afterword',
+  'appendix',
+  'backlink',
+  'biblioentry',
+  'bibliography',
+  'biblioref',
+  'chapter',
+  'colophon',
+  'conclusion',
+  'cover',
+  'credit',
+  'credits',
+  'dedication',
+  'endnote',
+  'endnotes',
+  'epigraph',
+  'epilogue',
+  'errata',
+  'example',
+  'footnote',
+  'foreword',
+  'glossary',
+  'glossref',
+  'index',
+  'introduction',
+  'noteref',
+  'notice',
+  'pagebreak',
+  'pagelist',
+  'pagefooter',
+  'pageheader',
+  'part',
+  'preface',
+  'prologue',
+  'pullquote',
+  'qna',
+  'subtitle',
+  'tip',
+  'toc',
+];
+
+/**
+ * Process Element node.
+ * @param node - Node of HAST.
+ * @param index - Index of the node in parent.
+ * @param parent - Parent of the node.
+ */
+const visitor: Visitor<Element> = (node) => {
+  if (!(node.properties && Array.isArray(node.properties.className))) {
+    return;
+  }
+
+  for (const className of node.properties.className) {
+    if (typeof className === 'string' && targetClassNames.includes(className)) {
+      if (Array.isArray(node.properties.role)) {
+        node.properties.role.push(`doc-${className}`);
+      } else {
+        node.properties.role = [`doc-${className}`];
+      }
+    }
+  }
+};
+
+/**
+ * If any element in HAST has a vocabulary class defined in DPUB-ARIA, add the corresponding `role` attribute.
+ * @see https://w3c.github.io/dpub-aria/#roles
+ */
+export const hast = () => (tree: Node) => {
+  visit<Element>(tree, 'element', visitor);
+};

--- a/src/revive-rehype.ts
+++ b/src/revive-rehype.ts
@@ -9,6 +9,7 @@ import {
   handlerInlineMath as inlineMath,
 } from './plugins/math';
 import { handler as ruby } from './plugins/ruby';
+import { hast as waiAria } from './plugins/wai-aria-role';
 import { inspect } from './utils';
 
 /**
@@ -32,5 +33,6 @@ export const reviveRehype = [
   raw,
   figure,
   footnotes,
+  waiAria,
   inspect('hast'),
 ] as unified.PluggableList<unified.Settings>;

--- a/tests/wai-aria-role.test.ts
+++ b/tests/wai-aria-role.test.ts
@@ -18,3 +18,14 @@ it('doc-chapter', () => {
   const expected = `<section class="level1" aria-labelledby="example"><h1 class="example" id="example" role="doc-example">Example</h1></section>`;
   expect(received).toBe(expected);
 });
+
+it('If the role already exists, skip adding it.', () => {
+  const md = `# Appendix {.appendix}
+<h2 class="example" role="doc-appendix">Example 1</h2>
+<h2 class="example">Example 2</h2>
+`;
+  const received = stringify(md, options);
+  const expected = `<section class="level1" aria-labelledby="appendix"><h1 class="appendix" id="appendix" role="doc-appendix">Appendix</h1><h2 class="example" role="doc-appendix">Example 1</h2>
+<h2 class="example" role="doc-example">Example 2</h2></section>`;
+  expect(received).toBe(expected);
+});

--- a/tests/wai-aria-role.test.ts
+++ b/tests/wai-aria-role.test.ts
@@ -1,0 +1,20 @@
+import { stringify } from '../src/index';
+
+const options = {
+  partial: true,
+  disableFormatHtml: true,
+};
+
+it('doc-appendix', () => {
+  const md = `# Appendix {.appendix}`;
+  const received = stringify(md, options);
+  const expected = `<section class="level1" aria-labelledby="appendix"><h1 class="appendix" id="appendix" role="doc-appendix">Appendix</h1></section>`;
+  expect(received).toBe(expected);
+});
+
+it('doc-chapter', () => {
+  const md = `# Example {.example}`;
+  const received = stringify(md, options);
+  const expected = `<section class="level1" aria-labelledby="example"><h1 class="example" id="example" role="doc-example">Example</h1></section>`;
+  expect(received).toBe(expected);
+});


### PR DESCRIPTION
refs: #28

VFM v2 残件のうち対応が容易そうだったので、WAI-ARIA role を実装してみました。記法の追加ではなく https://github.com/vivliostyle/vfm/issues/28#issuecomment-768171789 のように DPUB-ARIA へ定義されているクラス名を持つ要素があれば対応する role を doc-xxxx として追加します。