### PR TITLE
fix: HTML block causes wrong sectioning (vfm 2.2.0)

### DIFF
--- a/src/plugins/section.ts
+++ b/src/plugins/section.ts
@@ -114,8 +114,6 @@ const sectionizeIfRequired = (node: any, ancestors: Parent[], file: VFile) => {
         return true;
       }
     }
-      }
-    }
     return false;
   };
 

--- a/src/plugins/section.ts
+++ b/src/plugins/section.ts
@@ -87,28 +87,33 @@ const sectionizeIfRequired = (node: any, ancestors: Parent[], file: VFile) => {
 
   // check if it's HTML end tag without corresponding start tag in sibling nodes.
   const isHtmlEnd = (node: any) => {
-    if (node.type === 'html') {
-      const tag = /<\/([^>\s]+)\s*>[^<]*$/.exec(node.value)?.[1];
-      if (tag) {
-        // it's HTML end tag, check if it has corresponding start tag
-        const isHtmlStart = (node: any) =>
-          node.type === 'html' &&
-          new RegExp(`<${tag}\\b[^>]*>`).test(node.value);
-        const htmlStart = findAfter(parent, start, isHtmlStart);
-        if (
-          !htmlStart ||
-          parent.children.indexOf(htmlStart) > parent.children.indexOf(node)
-        ) {
-          // corresponding start tag is not found in this section level,
-          // check if it is found earlier.
-          const htmlStart1 = findAfter(parent, 0, isHtmlStart);
-          if (
-            htmlStart1 &&
-            parent.children.indexOf(htmlStart1) < parent.children.indexOf(start)
-          ) {
-            return true;
-          }
-        }
+    if (node.type !== 'html') {
+      return false;
+    }
+
+    const tag = /<\/([^>\s]+)\s*>[^<]*$/.exec(node.value)?.[1];
+    if (!tag) {
+      return false;
+    }
+
+    // it's HTML end tag, check if it has corresponding start tag
+    const isHtmlStart = (node: any) =>
+      node.type === 'html' && new RegExp(`<${tag}\\b[^>]*>`).test(node.value);
+    const htmlStart = findAfter(parent, start, isHtmlStart);
+    if (
+      !htmlStart ||
+      parent.children.indexOf(htmlStart) > parent.children.indexOf(node)
+    ) {
+      // corresponding start tag is not found in this section level,
+      // check if it is found earlier.
+      const htmlStart1 = findAfter(parent, 0, isHtmlStart);
+      if (
+        htmlStart1 &&
+        parent.children.indexOf(htmlStart1) < parent.children.indexOf(start)
+      ) {
+        return true;
+      }
+    }
       }
     }
     return false;

--- a/src/plugins/section.ts
+++ b/src/plugins/section.ts
@@ -87,18 +87,28 @@ const sectionizeIfRequired = (node: any, ancestors: Parent[], file: VFile) => {
 
   // check if it's HTML end tag without corresponding start tag in sibling nodes.
   const isHtmlEnd = (node: any) => {
-    if (node.type === 'html' && node.value.startsWith('</')) {
-      // it's HTML end tag, check if it has corresponding start tag
-      const tag = /^<\/([^>\s]+)/.exec(node.value)?.[1];
-      const isHtmlStart = (node: any) =>
-        node.type === 'html' && /^<([^>\s]+)/.exec(node.value)?.[1] === tag;
-      const htmlStart = findAfter(parent, start, isHtmlStart);
-      if (
-        !htmlStart ||
-        parent.children.indexOf(htmlStart) > parent.children.indexOf(node)
-      ) {
-        // corresponding start tag not found in sibling nodes
-        return true;
+    if (node.type === 'html') {
+      const tag = /<\/([^>\s]+)\s*>[^<]*$/.exec(node.value)?.[1];
+      if (tag) {
+        // it's HTML end tag, check if it has corresponding start tag
+        const isHtmlStart = (node: any) =>
+          node.type === 'html' &&
+          new RegExp(`<${tag}\\b[^>]*>`).test(node.value);
+        const htmlStart = findAfter(parent, start, isHtmlStart);
+        if (
+          !htmlStart ||
+          parent.children.indexOf(htmlStart) > parent.children.indexOf(node)
+        ) {
+          // corresponding start tag is not found in this section level,
+          // check if it is found earlier.
+          const htmlStart1 = findAfter(parent, 0, isHtmlStart);
+          if (
+            htmlStart1 &&
+            parent.children.indexOf(htmlStart1) < parent.children.indexOf(start)
+          ) {
+            return true;
+          }
+        }
       }
     }
     return false;


### PR DESCRIPTION
- fix #183

この不具合は、 #174 で追加したHTMLブロックでの終了タグがあったら対応する開始タグが同じセクションのレベルになかったらセクションを閉じるようにするという処理に問題があり発生していました。

複数の終了タグからなるHTMLブロック（例 `</td></tr></table>`）があったとき、今回の修正前は、その最初の終了タグのタグ名（この例では `td`）の開始タグではじまるHTMLブロックを見つけるようにしていました。これでは対応する開始タグが見つからない（`<table><tr><td>` というHTMLブロックではマッチしない）ということがあるため、この不具合が起きていました。

この修正後では、HTMLブロック内に複数のタグがあっても問題ないように、HTMLブロック内の最後の終了タグと対応する開始タグを見つけるようにしました。

また、対応する開始タグが同じセクションのレベルになかった場合、それより前に見つかるかどうかをチェックして、もし見つからなかった場合は、セクションを閉じることはしないようにしました。
