### PR TITLE
fix: Raw HTML のサンプル HTML を最新の Section 仕様に修正

### DIFF
--- a/docs/ja/vfm.md
+++ b/docs/ja/vfm.md
@@ -515,8 +515,8 @@ display: $$1 + 1 = 2$$
 
 ```html
 <div class="custom">
-  <section id="heading" class="level1">
-    <h1>Heading</h1>
+  <section class="level1" aria-labelledby="heading">
+    <h1 id="heading">Heading</h1>
   </section>
 </div>
 ```

--- a/docs/vfm.md
+++ b/docs/vfm.md
@@ -515,8 +515,8 @@ It also outputs `<script>` for processing MathJax if `math` is enabled and the m
 
 ```html
 <div class="custom">
-  <section id="heading" class="level1">
-    <h1>Heading</h1>
+  <section class="level1" aria-labelledby="heading">
+    <h1 id="heading">Heading</h1>
   </section>
 </div>
 ```


### PR DESCRIPTION
VFM 構文ドキュメントにおいて Sectionization は最新仕様になっているが、Raw HTML のサンプル HTML は古いままだったので修正。