### PR TITLE
docs: improve sectionization example

### DIFF
--- a/docs/ja/vfm.md
+++ b/docs/ja/vfm.md
@@ -586,7 +586,15 @@ ruby rt {
 
 ## Level 2
 
-> # Not Sectionize
+### Level 3
+
+##
+
+Level 2 was ended by `##`.
+
+## Not Sectionize {.just-a-heading} ##
+
+> # Not Sectionize in Blockquote
 ```
 
 **HTML**
@@ -605,10 +613,15 @@ ruby rt {
   <h1 id="level-1">Level 1</h1>
   <section class="level2" aria-labelledby="level-2">
     <h2 id="level-2">Level 2</h2>
-    <blockquote>
-      <h1 id="not-sectionize">Not Sectionize</h1>
-    </blockquote>
+    <section class="level3" aria-labelledby="level-3">
+      <h3 id="level-3">Level 3</h3>
+    </section>
   </section>
+  <p>Level 2 was ended by <code>##</code>.</p>
+  <h2 class="just-a-heading" id="not-sectionize">Not Sectionize</h2>
+  <blockquote>
+    <h1 id="not-sectionize-in-blockquote">Not Sectionize in Blockquote</h1>
+  </blockquote>
 </section>
 ```
 
@@ -617,7 +630,11 @@ ruby rt {
 ```css
 body > section {
 }
-body > section > h1:first-child {
+
+section[aria-labelledby="intro"] {
+}
+
+section:has(> h1.title) {
 }
 
 .level1 {

--- a/docs/vfm.md
+++ b/docs/vfm.md
@@ -586,7 +586,15 @@ Make the heading a hierarchical section.
 
 ## Level 2
 
-> # Not Sectionize
+### Level 3
+
+##
+
+Level 2 was ended by `##`.
+
+## Not Sectionize {.just-a-heading} ##
+
+> # Not Sectionize in Blockquote
 ```
 
 **HTML**
@@ -605,10 +613,15 @@ Make the heading a hierarchical section.
   <h1 id="level-1">Level 1</h1>
   <section class="level2" aria-labelledby="level-2">
     <h2 id="level-2">Level 2</h2>
-    <blockquote>
-      <h1 id="not-sectionize">Not Sectionize</h1>
-    </blockquote>
+    <section class="level3" aria-labelledby="level-3">
+      <h3 id="level-3">Level 3</h3>
+    </section>
   </section>
+  <p>Level 2 was ended by <code>##</code>.</p>
+  <h2 class="just-a-heading" id="not-sectionize">Not Sectionize</h2>
+  <blockquote>
+    <h1 id="not-sectionize-in-blockquote">Not Sectionize in Blockquote</h1>
+  </blockquote>
 </section>
 ```
 
@@ -617,7 +630,11 @@ Make the heading a hierarchical section.
 ```css
 body > section {
 }
-body > section > h1:first-child {
+
+section[aria-labelledby="intro"] {
+}
+
+section:has(> h1.title) {
 }
 
 .level1 {


### PR DESCRIPTION
セクション分けの例を修正しました。

- セクションを終了させる `##` だけの行の例を入れた
- セクション分けをしない見出しの例を入れた
- CSSセレクタの `body > section > h1:first-child` はあまり有用でないと思う（たぶんこの例が書かれたのはVFM v1で見出しの属性がsectionに付く仕様だったので見出しだけの選択がしにくかったことが関係する）ので削除
- sectionの選択に`aria-labelledby`属性を使った例を追加
- sectionの選択に`:has()`を使った例を追加