### PR TITLE
feat: プロジェクトを ESM 化

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "volta": {
     "node": "22.14.0"
   },
+  "type": "module",
   "main": "lib/index.js",
   "bin": {
     "vfm": "lib/cli.js"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@
 import fs from 'fs';
 import meow from 'meow';
 import readline from 'readline';
-import { stringify } from '.';
+import { stringify } from './index.js';
 
 const cli = meow(
   `

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,16 @@
 import rehypeFormat from 'rehype-format';
 import rehypeStringify from 'rehype-stringify';
 import unified, { Processor } from 'unified';
-import { mdast as doc } from './plugins/document';
-import { hast as hastMath } from './plugins/math';
-import { Metadata, readMetadata } from './plugins/metadata';
-import { replace as handleReplace, ReplaceRule } from './plugins/replace';
-import { reviveParse as markdown } from './revive-parse';
-import { reviveRehype as html } from './revive-rehype';
-import { debug } from './utils';
+import { mdast as doc } from './plugins/document.js';
+import { hast as hastMath } from './plugins/math.js';
+import { Metadata, readMetadata } from './plugins/metadata.js';
+import { replace as handleReplace, ReplaceRule } from './plugins/replace.js';
+import { reviveParse as markdown } from './revive-parse.js';
+import { reviveRehype as html } from './revive-rehype.js';
+import { debug } from './utils.js';
 
 // Expose metadata reading by VFM
-export * from './plugins/metadata';
+export * from './plugins/metadata.js';
 
 /**
  * Option for convert Markdown to a stringify (HTML).

--- a/src/plugins/document.ts
+++ b/src/plugins/document.ts
@@ -2,7 +2,7 @@ import doctype from 'doctype';
 import h from 'hastscript';
 import { Node } from 'unist';
 import { VFile } from 'vfile';
-import { Attribute, Metadata } from './metadata';
+import { Attribute, Metadata } from './metadata.js';
 
 /**
  * Create AST properties from attributes.

--- a/src/plugins/metadata.ts
+++ b/src/plugins/metadata.ts
@@ -11,8 +11,8 @@ import { Node } from 'unist';
 import { select } from 'unist-util-select';
 import visit from 'unist-util-visit';
 import { VFile } from 'vfile';
-import { mdast as attr } from './attr';
-import { mdast as footnotes } from './footnotes';
+import { mdast as attr } from './attr.js';
+import { mdast as footnotes } from './footnotes.js';
 
 /** Attribute of HTML tag. */
 export type Attribute = {

--- a/src/revive-parse.ts
+++ b/src/revive-parse.ts
@@ -2,15 +2,15 @@ import breaks from 'remark-breaks';
 import frontmatter from 'remark-frontmatter';
 import markdown from 'remark-parse';
 import unified from 'unified';
-import { mdast as attr } from './plugins/attr';
-import { mdast as code } from './plugins/code';
-import { mdast as footnotes } from './plugins/footnotes';
-import { mdast as math } from './plugins/math';
-import { mdast as ruby } from './plugins/ruby';
-import { mdast as section } from './plugins/section';
-import { mdast as slug } from './plugins/slug';
-import { mdast as toc } from './plugins/toc';
-import { inspect } from './utils';
+import { mdast as attr } from './plugins/attr.js';
+import { mdast as code } from './plugins/code.js';
+import { mdast as footnotes } from './plugins/footnotes.js';
+import { mdast as math } from './plugins/math.js';
+import { mdast as ruby } from './plugins/ruby.js';
+import { mdast as section } from './plugins/section.js';
+import { mdast as slug } from './plugins/slug.js';
+import { mdast as toc } from './plugins/toc.js';
+import { inspect } from './utils.js';
 
 /**
  * Create Markdown AST parsers.

--- a/src/revive-rehype.ts
+++ b/src/revive-rehype.ts
@@ -1,15 +1,15 @@
 import raw from 'rehype-raw';
 import remark2rehype from 'remark-rehype';
 import unified from 'unified';
-import { handler as code } from './plugins/code';
-import { hast as figure } from './plugins/figure';
-import { hast as footnotes } from './plugins/footnotes';
+import { handler as code } from './plugins/code.js';
+import { hast as figure } from './plugins/figure.js';
+import { hast as footnotes } from './plugins/footnotes.js';
 import {
   handlerDisplayMath as displayMath,
   handlerInlineMath as inlineMath,
-} from './plugins/math';
-import { handler as ruby } from './plugins/ruby';
-import { inspect } from './utils';
+} from './plugins/math.js';
+import { handler as ruby } from './plugins/ruby.js';
+import { inspect } from './utils.js';
 
 /**
  * Create Hypertext AST handlers and transformers.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,10 @@
 {
   "exclude": ["tests", "lib"],
   "compilerOptions": {
-    "target": "es5",
-    "module": "commonjs",
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ESNext", "DOM"],
     "declaration": true,
     "outDir": "./lib",
     "rootDir": "./src",


### PR DESCRIPTION
- vivliostyle-cli を参考にプロジェクトを ESM 化
- tsconfig を調整
- package.json を調整
- プロジェクト内ファイルの import に拡張子を追加
  - ESM として Transpile された JavaScript と同様に `.js` としています
