### PR TITLE
fix: Correct import and usage of findAndReplace from mdast-util-find-and-replace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10367,21 +10367,6 @@
         }
       }
     },
-    "node_modules/vite-node/node_modules/yaml": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/vitest": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.0.8.tgz",
@@ -10574,21 +10559,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitest/node_modules/yaml": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/wcwidth": {

--- a/types/remark.d.ts
+++ b/types/remark.d.ts
@@ -11,7 +11,7 @@ declare module 'hast-util-select';
 declare module 'hastscript';
 declare module 'mdast-util-to-hast/lib/all.js';
 declare module 'mdast-util-to-string';
-declare module 'mdast-util-find-and-replace';
+// declare module 'mdast-util-find-and-replace';
 declare module 'rehype-katex';
 declare module 'remark-slug';
 declare module 'rehype-slug';


### PR DESCRIPTION
#199 で、ビルドとテストは成功するがCLIが起動しなくなるimportのミスがありました。types/remark.d.tsが悪さをして型チェックを回避してしまうようです。スタブ型定義をコメントアウトし、パッケージから提供される型定義を直接使うように変更しました。また、正しい型定義でビルドが通るように型情報を整理しました。

> @akabekobeko types/remark.d.tsに定義されているスタブ型定義は、mdast-util-find-and-replaceのほかにも、意図せず型チェックを回避してしまっているものがありそうです。整理する方針で進めますか？　こんな感じになりそうです。https://github.com/vivliostyle/vfm/compare/main...u1f992:vfm:fix/remove-type-stubs

→同内容でPRを作成しました（#202 ）