### PR TITLE
feat: Add option to reverse figcaption and img order

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,16 +10,17 @@ const cli = meow(
     Usage
       $ vfm <filename>
       $ echo <string> | vfm
- 
+
     Options
-      --style, -s            Custom stylesheet path/URL
-      --partial, -p          Output markdown fragments
-      --title                Document title (ignored in partial mode)
-      --language             Document language (ignored in partial mode)
-      --hard-line-breaks     Add <br> at the position of hard line breaks, without needing spaces
-      --disable-format-html  Disable automatic HTML format
-      --disable-math         Disable math syntax
- 
+      --style, -s                  Custom stylesheet path/URL
+      --partial, -p                Output markdown fragments
+      --title                      Document title (ignored in partial mode)
+      --language                   Document language (ignored in partial mode)
+      --hard-line-breaks           Add <br> at the position of hard line breaks, without needing spaces
+      --disable-format-html        Disable automatic HTML format
+      --disable-math               Disable math syntax
+      --img-figcaption-order       Order of img and figcaption elements in figure (img-figcaption or figcaption-img)
+
     Examples
       $ vfm input.md
 `,
@@ -50,6 +51,10 @@ const cli = meow(
       disableMath: {
         type: 'boolean',
       },
+      imgFigcaptionOrder: {
+        type: 'string',
+        choices: ['img-figcaption', 'figcaption-img'],
+      },
     },
   },
 );
@@ -65,6 +70,10 @@ function compile(input: string) {
       hardLineBreaks: cli.flags.hardLineBreaks,
       disableFormatHtml: cli.flags.disableFormatHtml,
       math: cli.flags.disableMath === undefined ? true : !cli.flags.disableMath,
+      imgFigcaptionOrder: cli.flags.imgFigcaptionOrder as
+        | 'img-figcaption'
+        | 'figcaption-img'
+        | undefined,
     }),
   );
 }
@@ -78,6 +87,7 @@ function main(
     hardLineBreaks: { type: 'boolean' };
     disableFormatHtml: { type: 'boolean' };
     disableMath: { type: 'boolean' };
+    imgFigcaptionOrder: { type: 'string' };
   }>,
 ) {
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,8 @@ export interface StringifyMarkdownOptions {
   disableFormatHtml?: boolean;
   /** Enable math syntax. */
   math?: boolean;
+  /** Order of img and figcaption elements in figure. */
+  imgFigcaptionOrder?: 'img-figcaption' | 'figcaption-img';
 }
 
 export interface Hooks {
@@ -93,6 +95,7 @@ export function VFM(
     hardLineBreaks = false,
     disableFormatHtml = false,
     math = true,
+    imgFigcaptionOrder = undefined,
   }: StringifyMarkdownOptions = {},
   metadata: Metadata = {},
 ): Processor {
@@ -112,12 +115,15 @@ export function VFM(
     if (metadata.vfm.disableFormatHtml !== undefined) {
       disableFormatHtml = metadata.vfm.disableFormatHtml;
     }
+    if (metadata.vfm.imgFigcaptionOrder !== undefined) {
+      imgFigcaptionOrder = metadata.vfm.imgFigcaptionOrder;
+    }
   }
 
   const processor = unified()
     .use(markdown(hardLineBreaks, math))
     .data('settings', { position: true })
-    .use(html);
+    .use(html({ imgFigcaptionOrder }));
 
   if (replace) {
     processor.use(handleReplace, { rules: replace });

--- a/src/plugins/metadata.ts
+++ b/src/plugins/metadata.ts
@@ -36,6 +36,8 @@ export type VFMSettings = {
   theme?: string;
   /** Enable TOC mode. */
   toc?: boolean;
+  /** Order of img and figcaption elements in figure. */
+  imgFigcaptionOrder?: 'img-figcaption' | 'figcaption-img';
 };
 
 /** Metadata from Frontmatter. */

--- a/src/revive-rehype.ts
+++ b/src/revive-rehype.ts
@@ -2,7 +2,7 @@ import raw from 'rehype-raw';
 import remark2rehype from 'remark-rehype';
 import unified from 'unified';
 import { handler as code } from './plugins/code.js';
-import { hast as figure } from './plugins/figure.js';
+import { hast as figure, FigureOptions } from './plugins/figure.js';
 import { hast as footnotes } from './plugins/footnotes.js';
 import {
   handlerDisplayMath as displayMath,
@@ -11,12 +11,16 @@ import {
 import { handler as ruby } from './plugins/ruby.js';
 import { inspect } from './utils.js';
 
+export type ReviveRehypeOptions = FigureOptions;
+
 /**
  * Create Hypertext AST handlers and transformers.
- * @param enableMath Enable math syntax.
+ * @param options Options for rehype transformers.
  * @returns Handlers and transformers.
  */
-export const reviveRehype = [
+export const reviveRehype = (
+  options?: ReviveRehypeOptions,
+) => [
   [
     remark2rehype,
     {
@@ -30,7 +34,7 @@ export const reviveRehype = [
     },
   ],
   raw,
-  figure,
+  [figure, options],
   footnotes,
   inspect('hast'),
 ] as unified.PluggableList<unified.Settings>;

--- a/tests/figure.test.ts
+++ b/tests/figure.test.ts
@@ -79,3 +79,31 @@ test(
     `<figure><img src="./img.png" alt="caption" title="title" id="image" data-sample="sample"><figcaption aria-hidden="true">caption</figcaption></figure>`,
   ),
 );
+
+test(
+  'imgFigcaptionOrder: figcaption-img',
+  buildProcessorTestingCode(
+    `![caption](./img.png)`,
+    stripIndent`
+    root[1]
+    └─0 paragraph[1]
+        └─0 image
+              title: null
+              url: "./img.png"
+              alt: "caption"
+    `,
+    `<figure><figcaption aria-hidden="true">caption</figcaption><img src="./img.png" alt="caption"></figure>`,
+    { imgFigcaptionOrder: 'figcaption-img' },
+  ),
+);
+
+test(
+  'imgFigcaptionOrder should not affect raw HTML figure',
+  buildProcessorTestingCode(
+    `<figure><img src="./img.png" alt="caption"><figcaption>caption</figcaption></figure>`,
+    `root[1]
+└─0 html "<figure><img src=\\"./img.png\\" alt=\\"caption\\"><figcaption>caption</figcaption></figure>"`,
+    `<figure><img src="./img.png" alt="caption"><figcaption>caption</figcaption></figure>`,
+    { imgFigcaptionOrder: 'figcaption-img' },
+  ),
+);

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -23,6 +23,7 @@ export const buildProcessorTestingCode =
       hardLineBreaks = false,
       disableFormatHtml = true,
       math = false,
+      imgFigcaptionOrder = undefined,
     }: StringifyMarkdownOptions = {},
   ) =>
   (): any => {
@@ -35,6 +36,7 @@ export const buildProcessorTestingCode =
       hardLineBreaks,
       disableFormatHtml,
       math,
+      imgFigcaptionOrder,
     }).freeze();
     const R = / \(.+?\)$/gm; // Remove position information
     expect(unistInspectNoColor(vfm.parse(input)).replace(R, '')).toBe(


### PR DESCRIPTION
closes: #208 

新たなオプション`imgFigcaptionOrder: 'img-figcaption' | 'figcaption-img'`を追加し、順番変更に対応します。このオプションはMarkdown→HTML変換にだけ適用され、HTMLで直接記述された`figure`には影響しません。

revive-rehype.tsの`reviveRehype`は現在は単に`PluggableList`を返しオプションを取れる形ではなかったので関数に変更しています。