### PR TITLE
feat: Support attribute syntax for fenced code blocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "hast-util-select": "^5.0.5",
         "hastscript": "^7.2.0",
         "js-yaml": "^4.1.0",
+        "md-attr-parser": "^1.3.0",
         "mdast-util-find-and-replace": "^2.2.2",
         "mdast-util-to-hast": "^11.3.0",
         "mdast-util-to-string": "^3.2.0",
@@ -8028,21 +8029,6 @@
         }
       }
     },
-    "node_modules/vite-node/node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      }
-    },
     "node_modules/vitest": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.0.8.tgz",
@@ -8210,21 +8196,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitest/node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
       }
     },
     "node_modules/web-namespaces": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "hast-util-select": "^5.0.5",
     "hastscript": "^7.2.0",
     "js-yaml": "^4.1.0",
+    "md-attr-parser": "^1.3.0",
     "mdast-util-find-and-replace": "^2.2.2",
     "mdast-util-to-hast": "^11.3.0",
     "mdast-util-to-string": "^3.2.0",

--- a/src/plugins/attr.ts
+++ b/src/plugins/attr.ts
@@ -15,6 +15,7 @@ export const mdast = [
       'reference',
       'footnoteCall',
       'autoLink',
+      'fencedCode',
     ],
   },
 ];

--- a/src/plugins/code.ts
+++ b/src/plugins/code.ts
@@ -1,43 +1,157 @@
-import { Root } from 'mdast';
+import { ElementContent as HastElementContent } from 'hast';
+import { Code, Root } from 'mdast';
 import { Handler } from 'mdast-util-to-hast';
+import parseAttr from 'md-attr-parser';
 import refractor from 'refractor';
 import { Node } from 'unist';
 import { u } from 'unist-builder';
 import { visit } from 'unist-util-visit';
 
+interface HProperties {
+  id?: string;
+  class?: string[];
+  title?: string;
+  [key: string]: unknown;
+}
+declare module 'mdast' {
+  interface Code {
+    data?: {
+      hProperties?: HProperties;
+      hChildren?: HastElementContent[] | ReturnType<typeof refractor.highlight>;
+    };
+  }
+}
+function getHProperties(node: Code): HProperties {
+  return (node.data?.hProperties as HProperties) ?? {};
+}
+function setHProperties(node: Code, props: HProperties): void {
+  node.data = { ...(node.data ?? {}), hProperties: props };
+}
+
+/**
+ * Parse `lang:title` syntax and extract title to hProperties.
+ */
+function extractLangTitle(node: Code): void {
+  const match = /^(.+?):(.+)$/.exec(node.lang ?? '');
+  if (!match) return;
+
+  const [, lang, title] = match;
+  setHProperties(node, { ...getHProperties(node), title });
+  node.lang = lang;
+  if (node.position?.end.offset) {
+    node.position.end.offset -= title.length + 1;
+  }
+}
+
+/**
+ * Parse key=value metadata from meta string.
+ */
+function parseMetadata(meta: string): Record<string, string> {
+  const matches = meta.match(/(?:([^"\s]+?)=([^"\s]+)|([^"\s]+)="([^"]*?)")/g);
+  if (!matches) return {};
+
+  return Object.fromEntries(
+    matches.map((str) => {
+      const [k, v] = str.split('=');
+      return [k, v.replace(/(^"|"$)/g, '')];
+    }),
+  );
+}
+
+/**
+ * Check if a position in the string is inside a quoted value.
+ * Note: Escaped quotes are not considered as parseMetadata doesn't support them.
+ */
+function isInsideQuotes(meta: string, pos: number): boolean {
+  let inQuotes = false;
+  for (let i = 0; i < pos; i++) {
+    if (meta[i] === '"') {
+      inQuotes = !inQuotes;
+    }
+  }
+  return inQuotes;
+}
+
+/**
+ * Find valid `{...}` attribute block in meta string.
+ */
+function findValidAttrBlock(
+  meta: string,
+): { prop: HProperties; eaten: string } | null {
+  let searchStart = 0;
+  while (searchStart < meta.length) {
+    const braceIndex = meta.indexOf('{', searchStart);
+    if (braceIndex === -1) break;
+
+    // Skip if inside quoted string like title="foo {#bar}"
+    if (isInsideQuotes(meta, braceIndex)) {
+      searchStart = braceIndex + 1;
+      continue;
+    }
+
+    // Attribute block must be at start or preceded by whitespace
+    // This prevents matching `{...}` inside values like `title=foo{#bar}`
+    if (braceIndex > 0 && !/\s/.test(meta[braceIndex - 1])) {
+      searchStart = braceIndex + 1;
+      continue;
+    }
+
+    const parsed = parseAttr(meta.slice(braceIndex));
+    const hasValidAttrs =
+      parsed.prop.id !== undefined ||
+      parsed.prop.class !== undefined ||
+      Object.values(parsed.prop).some((v) => v !== undefined);
+
+    if (parsed.eaten && parsed.eaten.startsWith('{') && hasValidAttrs) {
+      return parsed;
+    }
+    searchStart = braceIndex + 1;
+  }
+  return null;
+}
+
+/**
+ * Process meta string to extract title and `{...}` attributes.
+ */
+function processMeta(node: Code): void {
+  if (!node.meta) return;
+
+  const metadata = parseMetadata(node.meta);
+
+  // copy title metadata for figure handler injecting figcaption
+  if (metadata.title) {
+    setHProperties(node, { ...getHProperties(node), title: metadata.title });
+  }
+
+  // Find and apply valid `{...}` attribute block
+  const attrBlock = findValidAttrBlock(node.meta);
+  const existingTitle = getHProperties(node).title;
+
+  if (attrBlock) {
+    setHProperties(node, {
+      ...(existingTitle ? { title: existingTitle } : {}),
+      ...attrBlock.prop,
+    });
+  } else {
+    // No valid `{...}` in meta, only keep title
+    setHProperties(node, existingTitle ? { title: existingTitle } : {});
+  }
+}
+
 export function mdast() {
   return (tree: Node) => {
     visit(tree as Root, 'code', (node) => {
-      const match = /^(.+?):(.+)$/.exec(node.lang ?? '');
-
-      // parse lang:title syntax
-      if (match) {
-        const [, lang, title] = match;
-        node.data = { ...(node.data ?? {}), hProperties: { title } };
-        node.lang = lang;
-        if (node.position?.end.offset) {
-          node.position.end.offset -= title.length + 1;
-        }
+      /**
+       * Workaround for remark-attr's "bad hack".
+       * When meta is null, remark-attr parses code content as attributes.
+       * @see https://github.com/arobase-che/remark-attr/blob/325f0ef730eafa601c9b631ea175b26c18c85a4a/src/index.js#L260-L263
+       */
+      if (!node.meta && node.data?.hProperties) {
+        delete node.data.hProperties;
       }
 
-      if (node.meta) {
-        const metadata = Object.fromEntries(
-          node.meta
-            .match(/(?:([^"\s]+?)=([^"\s]+)|([^"\s]+)="([^"]*?)")/g)
-            ?.map((str) => {
-              const [k, v] = str.split('=');
-              return [k, v.replace(/(^"|"$)/g, '')];
-            }) ?? [],
-        );
-
-        // copy title metadata for figure handler injecting figcaption
-        if (metadata.title) {
-          node.data = {
-            ...(node.data ?? {}),
-            hProperties: { title: metadata.title },
-          };
-        }
-      }
+      extractLangTitle(node);
+      processMeta(node);
 
       // syntax highlight
       if (node.lang && refractor.registered(node.lang)) {
@@ -51,8 +165,21 @@ export function mdast() {
 export function handler(h: any, node: any): Handler {
   const value = node.value || '';
   const lang = node.lang ? node.lang.match(/^[^ \t]+(?=[ \t]|$)/) : 'text';
-  const props = { className: ['language-' + lang] };
-  return h(node.position, 'pre', props, [
-    h(node, 'code', props, [u('text', value)]),
+  const langClass = 'language-' + lang;
+
+  // Merge language-* class with hProperties.class if present
+  const hProps = node.data?.hProperties ?? {};
+  const hClass = hProps.class;
+  const className = hClass
+    ? [langClass, ...(Array.isArray(hClass) ? hClass : [hClass])]
+    : [langClass];
+
+  const preProps = { className: [langClass] };
+  const codeProps = { ...hProps, className };
+  // Use hChildren for syntax highlighting if available, otherwise plain text
+  const children = node.data?.hChildren ?? [u('text', value)];
+
+  return h(node.position, 'pre', preProps, [
+    h(node.position, 'code', codeProps, children),
   ]);
 }

--- a/tests/code.test.ts
+++ b/tests/code.test.ts
@@ -55,3 +55,165 @@ test(
     `<figure class="language-js"><figcaption>app.js</figcaption><pre class="language-js"><code class="language-js"><span class="token string">'Hello code'</span></code></pre></figure>`,
   ),
 );
+
+test(
+  'code with id attribute',
+  buildProcessorTestingCode(
+    stripIndent`
+    \`\`\`js {#code-id}
+    'Hello code'
+    \`\`\`
+    `,
+    stripIndent`
+    root[1]
+    └─0 code "'Hello code'"
+          lang: "js"
+          meta: "{#code-id}"
+    `,
+    `<pre class="language-js"><code id="code-id" class="language-js"><span class="token string">'Hello code'</span></code></pre>`,
+  ),
+);
+
+test(
+  'code with title and id attribute',
+  buildProcessorTestingCode(
+    stripIndent`
+    \`\`\`js:app.js {#code-id}
+    'Hello code'
+    \`\`\`
+    `,
+    stripIndent`
+    root[1]
+    └─0 code "'Hello code'"
+          lang: "js:app.js"
+          meta: "{#code-id}"
+    `,
+    `<figure class="language-js"><figcaption>app.js</figcaption><pre class="language-js"><code id="code-id" class="language-js"><span class="token string">'Hello code'</span></code></pre></figure>`,
+  ),
+);
+
+test(
+  'code with multiple attributes',
+  buildProcessorTestingCode(
+    stripIndent`
+    \`\`\`js {#code-id .highlight data-line="1"}
+    'Hello code'
+    \`\`\`
+    `,
+    stripIndent`
+    root[1]
+    └─0 code "'Hello code'"
+          lang: "js"
+          meta: "{#code-id .highlight data-line=\\"1\\"}"
+    `,
+    `<pre class="language-js"><code id="code-id" class="language-js highlight" data-line="1"><span class="token string">'Hello code'</span></code></pre>`,
+  ),
+);
+
+test(
+  'code with title metadata and id attribute',
+  buildProcessorTestingCode(
+    stripIndent`
+    \`\`\`js title=app.js {#code-id}
+    'Hello code'
+    \`\`\`
+    `,
+    stripIndent`
+    root[1]
+    └─0 code "'Hello code'"
+          lang: "js"
+          meta: "title=app.js {#code-id}"
+    `,
+    `<figure class="language-js"><figcaption>app.js</figcaption><pre class="language-js"><code id="code-id" class="language-js"><span class="token string">'Hello code'</span></code></pre></figure>`,
+  ),
+);
+
+test(
+  'code with brace in title value',
+  buildProcessorTestingCode(
+    stripIndent`
+    \`\`\`js title={App}
+    'Hello code'
+    \`\`\`
+    `,
+    stripIndent`
+    root[1]
+    └─0 code "'Hello code'"
+          lang: "js"
+          meta: "title={App}"
+    `,
+    `<figure class="language-js"><figcaption>{App}</figcaption><pre class="language-js"><code class="language-js"><span class="token string">'Hello code'</span></code></pre></figure>`,
+  ),
+);
+
+test(
+  'code with brace in title value and id attribute',
+  buildProcessorTestingCode(
+    stripIndent`
+    \`\`\`js title={App} {#code-id}
+    'Hello code'
+    \`\`\`
+    `,
+    stripIndent`
+    root[1]
+    └─0 code "'Hello code'"
+          lang: "js"
+          meta: "title={App} {#code-id}"
+    `,
+    `<figure class="language-js"><figcaption>{App}</figcaption><pre class="language-js"><code id="code-id" class="language-js"><span class="token string">'Hello code'</span></code></pre></figure>`,
+  ),
+);
+
+test(
+  'code with attr-like brace in title value',
+  buildProcessorTestingCode(
+    stripIndent`
+    \`\`\`js title={#my-id}
+    'Hello code'
+    \`\`\`
+    `,
+    stripIndent`
+    root[1]
+    └─0 code "'Hello code'"
+          lang: "js"
+          meta: "title={#my-id}"
+    `,
+    `<figure class="language-js"><figcaption>{#my-id}</figcaption><pre class="language-js"><code class="language-js"><span class="token string">'Hello code'</span></code></pre></figure>`,
+  ),
+);
+
+test(
+  'code with attr-like brace continuing title value',
+  buildProcessorTestingCode(
+    stripIndent`
+    \`\`\`js title=title{#continue-title} {.this-is-expected-attr}
+    'Hello code'
+    \`\`\`
+    `,
+    stripIndent`
+    root[1]
+    └─0 code "'Hello code'"
+          lang: "js"
+          meta: "title=title{#continue-title} {.this-is-expected-attr}"
+    `,
+    `<figure class="language-js"><figcaption>title{#continue-title}</figcaption><pre class="language-js"><code class="language-js this-is-expected-attr"><span class="token string">'Hello code'</span></code></pre></figure>`,
+  ),
+);
+
+test(
+  'code with quoted title containing space and attr-like brace',
+  buildProcessorTestingCode(
+    stripIndent`
+    \`\`\`js title="title {#not-attr}" {#real-attr}
+    'Hello code'
+    \`\`\`
+    `,
+    stripIndent`
+    root[1]
+    └─0 code "'Hello code'"
+          lang: "js"
+          meta: "title=\\"title {#not-attr}\\" {#real-attr}"
+    `,
+    `<figure class="language-js"><figcaption>title {#not-attr}</figcaption><pre class="language-js"><code id="real-attr" class="language-js"><span class="token string">'Hello code'</span></code></pre></figure>`,
+  ),
+);

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -37,8 +37,14 @@ export const buildProcessorTestingCode =
       math,
     }).freeze();
     const R = / \(.+?\)$/gm; // Remove position information
-    expect(unistInspectNoColor(vfm.parse(input)).replace(R, '')).toBe(
-      expectedMdast.trim(),
-    );
+    // Remove data field from MDAST comparison.
+    // The data field is not part of the MDAST structure itself, but is used for
+    // coordination with subsequent processing (e.g., hProperties for HAST conversion).
+    // Therefore, validating the final HTML output is sufficient to confirm that the data
+    // was applied correctly.
+    const D = /\n +data: .+/gm;
+    expect(
+      unistInspectNoColor(vfm.parse(input)).replace(R, '').replace(D, ''),
+    ).toBe(expectedMdast.trim().replace(D, ''));
     expect(String(vfm.processSync(input))).toBe(expectedHtml);
   };

--- a/types/remark.d.ts
+++ b/types/remark.d.ts
@@ -22,6 +22,19 @@ declare module 'remark-breaks';
 // declare module 'to-vfile';
 // declare module 'unist-util-remove';
 declare module 'remark-attr';
+declare module 'md-attr-parser' {
+  export default function (
+    value: string,
+    indexNext?: number,
+  ): {
+    prop: {
+      id?: string;
+      class?: string[];
+      [key: string]: unknown;
+    };
+    eaten: string;
+  };
+}
 // declare module 'unist-util-find-after';
 // declare module 'doctype';
 


### PR DESCRIPTION
closes: #211 

fenced code <code>&#x60;&#x60;&#x60; ... &#x60;&#x60;&#x60;</code>で画像と同じ`{ ... }`による属性の付与を可能にします。想定している入力は追加したテストをご確認ください。既存のケースは壊していません。