### PR TITLE
feat: Add option to assign ID to figcaption

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,7 @@ const cli = meow(
       --disable-format-html        Disable automatic HTML format
       --disable-math               Disable math syntax
       --img-figcaption-order       Order of img and figcaption elements in figure (img-figcaption or figcaption-img)
+      --assign-id-to-figcaption    Assign ID to figcaption instead of img/code
 
     Examples
       $ vfm input.md
@@ -55,6 +56,9 @@ const cli = meow(
         type: 'string',
         choices: ['img-figcaption', 'figcaption-img'],
       },
+      assignIdToFigcaption: {
+        type: 'boolean',
+      },
     },
   },
 );
@@ -74,6 +78,7 @@ function compile(input: string) {
         | 'img-figcaption'
         | 'figcaption-img'
         | undefined,
+      assignIdToFigcaption: cli.flags.assignIdToFigcaption,
     }),
   );
 }
@@ -88,6 +93,7 @@ function main(
     disableFormatHtml: { type: 'boolean' };
     disableMath: { type: 'boolean' };
     imgFigcaptionOrder: { type: 'string' };
+    assignIdToFigcaption: { type: 'boolean' };
   }>,
 ) {
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,8 @@ export interface StringifyMarkdownOptions {
   math?: boolean;
   /** Order of img and figcaption elements in figure. */
   imgFigcaptionOrder?: 'img-figcaption' | 'figcaption-img';
+  /** Assign ID to figcaption instead of img/code. */
+  assignIdToFigcaption?: boolean;
 }
 
 export interface Hooks {
@@ -96,6 +98,7 @@ export function VFM(
     disableFormatHtml = false,
     math = true,
     imgFigcaptionOrder = undefined,
+    assignIdToFigcaption = false,
   }: StringifyMarkdownOptions = {},
   metadata: Metadata = {},
 ): Processor {
@@ -118,12 +121,15 @@ export function VFM(
     if (metadata.vfm.imgFigcaptionOrder !== undefined) {
       imgFigcaptionOrder = metadata.vfm.imgFigcaptionOrder;
     }
+    if (metadata.vfm.assignIdToFigcaption !== undefined) {
+      assignIdToFigcaption = metadata.vfm.assignIdToFigcaption;
+    }
   }
 
   const processor = unified()
     .use(markdown(hardLineBreaks, math))
     .data('settings', { position: true })
-    .use(html({ imgFigcaptionOrder }));
+    .use(html({ imgFigcaptionOrder, assignIdToFigcaption }));
 
   if (replace) {
     processor.use(handleReplace, { rules: replace });

--- a/src/plugins/metadata.ts
+++ b/src/plugins/metadata.ts
@@ -38,6 +38,8 @@ export type VFMSettings = {
   toc?: boolean;
   /** Order of img and figcaption elements in figure. */
   imgFigcaptionOrder?: 'img-figcaption' | 'figcaption-img';
+  /** Assign ID to figcaption instead of img/code. */
+  assignIdToFigcaption?: boolean;
 };
 
 /** Metadata from Frontmatter. */
@@ -249,6 +251,10 @@ const readSettings = (data: any): VFMSettings => {
         : undefined,
     theme: typeof data.theme === 'string' ? data.theme : undefined,
     toc: typeof data.toc === 'boolean' ? data.toc : false,
+    assignIdToFigcaption:
+      typeof data.assignIdToFigcaption === 'boolean'
+        ? data.assignIdToFigcaption
+        : false,
   };
 };
 

--- a/tests/code.test.ts
+++ b/tests/code.test.ts
@@ -217,3 +217,60 @@ test(
     `<figure class="language-js"><figcaption>title {#not-attr}</figcaption><pre class="language-js"><code id="real-attr" class="language-js"><span class="token string">'Hello code'</span></code></pre></figure>`,
   ),
 );
+
+test(
+  'code with title and id: assignIdToFigcaption moves ID from code to figcaption',
+  buildProcessorTestingCode(
+    stripIndent`
+    \`\`\`js:app.js {#code-id}
+    'Hello code'
+    \`\`\`
+    `,
+    stripIndent`
+    root[1]
+    └─0 code "'Hello code'"
+          lang: "js:app.js"
+          meta: "{#code-id}"
+    `,
+    `<figure class="language-js"><figcaption id="code-id">app.js</figcaption><pre class="language-js"><code class="language-js"><span class="token string">'Hello code'</span></code></pre></figure>`,
+    { assignIdToFigcaption: true },
+  ),
+);
+
+test(
+  'code with title metadata and id: assignIdToFigcaption moves ID from code to figcaption',
+  buildProcessorTestingCode(
+    stripIndent`
+    \`\`\`js title=app.js {#code-id}
+    'Hello code'
+    \`\`\`
+    `,
+    stripIndent`
+    root[1]
+    └─0 code "'Hello code'"
+          lang: "js"
+          meta: "title=app.js {#code-id}"
+    `,
+    `<figure class="language-js"><figcaption id="code-id">app.js</figcaption><pre class="language-js"><code class="language-js"><span class="token string">'Hello code'</span></code></pre></figure>`,
+    { assignIdToFigcaption: true },
+  ),
+);
+
+test(
+  'code with id but no title: assignIdToFigcaption has no effect (no figcaption)',
+  buildProcessorTestingCode(
+    stripIndent`
+    \`\`\`js {#code-id}
+    'Hello code'
+    \`\`\`
+    `,
+    stripIndent`
+    root[1]
+    └─0 code "'Hello code'"
+          lang: "js"
+          meta: "{#code-id}"
+    `,
+    `<pre class="language-js"><code id="code-id" class="language-js"><span class="token string">'Hello code'</span></code></pre>`,
+    { assignIdToFigcaption: true },
+  ),
+);

--- a/tests/figure.test.ts
+++ b/tests/figure.test.ts
@@ -107,3 +107,54 @@ test(
     { imgFigcaptionOrder: 'figcaption-img' },
   ),
 );
+
+test(
+  'assignIdToFigcaption moves ID from img to figcaption',
+  buildProcessorTestingCode(
+    `![caption](./img.png){#id}`,
+    stripIndent`
+    root[1]
+    └─0 paragraph[1]
+        └─0 image
+              title: null
+              url: "./img.png"
+              alt: "caption"
+    `,
+    `<figure><img src="./img.png" alt="caption"><figcaption aria-hidden="true" id="id">caption</figcaption></figure>`,
+    { assignIdToFigcaption: true },
+  ),
+);
+
+test(
+  'assignIdToFigcaption with imgFigcaptionOrder: figcaption-img',
+  buildProcessorTestingCode(
+    `![caption](./img.png){#id}`,
+    stripIndent`
+    root[1]
+    └─0 paragraph[1]
+        └─0 image
+              title: null
+              url: "./img.png"
+              alt: "caption"
+    `,
+    `<figure><figcaption aria-hidden="true" id="id">caption</figcaption><img src="./img.png" alt="caption"></figure>`,
+    { assignIdToFigcaption: true, imgFigcaptionOrder: 'figcaption-img' },
+  ),
+);
+
+test(
+  'assignIdToFigcaption: false keeps ID on img (default behavior)',
+  buildProcessorTestingCode(
+    `![caption](./img.png){#id}`,
+    stripIndent`
+    root[1]
+    └─0 paragraph[1]
+        └─0 image
+              title: null
+              url: "./img.png"
+              alt: "caption"
+    `,
+    `<figure><img src="./img.png" alt="caption" id="id"><figcaption aria-hidden="true">caption</figcaption></figure>`,
+    { assignIdToFigcaption: false },
+  ),
+);

--- a/tests/metadata.test.ts
+++ b/tests/metadata.test.ts
@@ -124,6 +124,7 @@ other-meta2: 'other2'
       disableFormatHtml: true,
       toc: false,
       theme: 'theme.css',
+      assignIdToFigcaption: false,
     },
   };
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -24,6 +24,7 @@ export const buildProcessorTestingCode =
       disableFormatHtml = true,
       math = false,
       imgFigcaptionOrder = undefined,
+      assignIdToFigcaption = undefined,
     }: StringifyMarkdownOptions = {},
   ) =>
   (): any => {
@@ -37,6 +38,7 @@ export const buildProcessorTestingCode =
       disableFormatHtml,
       math,
       imgFigcaptionOrder,
+      assignIdToFigcaption,
     }).freeze();
     const R = / \(.+?\)$/gm; // Remove position information
     // Remove data field from MDAST comparison.


### PR DESCRIPTION
closes: #210 

#209, #212 がマージされる前提なので後でrebaseします。

新たなオプション`assignIdToFigcaption: boolean`を追加して、`![caption](path){#id}`と<code>&#x60;&#x60;&#x60;lang {#id} 〜 &#x60;&#x60;&#x60;</code>について`figcaption`にIDがついたHTMLを得られるようにします。

