### PR TITLE
Add prepare script to packages/vfm for npx git execution

### DIFF
--- a/packages/vfm/package.json
+++ b/packages/vfm/package.json
@@ -34,6 +34,7 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "build": "shx rm -rf lib && tsc && shx chmod +x lib/cli.js",
+    "prepare": "npm run build",
     "dev": "tsc -w",
     "test": "vitest"
   },


### PR DESCRIPTION
#232 レビューで気づけず申し訳ないです。モノレポ化と同時に`prepare`スクリプトが消えていたのですが、この`prepare`スクリプトがあったことでVFMはTypeScriptプロジェクトでありながら`npx`から直接実行できるようになっていたことに気づきました。

<figure>
<figcaption>モノレポ化前 <code><a href="https://github.com/vivliostyle/vfm/commit/51fb813fa7eedcc0ffec17780df00388e954f513">51fb813</a></code></figcaption>

```shellsession
$ echo "# hello" | npx --yes --loglevel=silent "github:vivliostyle/vfm#51fb813fa7eedcc0ffec17780df00388e954f513" --partial

<section class="level1">
  <h1 id="hello">hello</h1>
</section>
```

</figure>
<figure>
<figcaption>モノレポ化後 <a href="3685b3c89f256fcd7e957547fc9c02323c4d3544"><code>3685b3c</code></a></figcaption>

```shellsession
$ echo "# hello" | npx --yes --loglevel=silent "git+https://github.com/vivliostyle/vfm.git#3685b3c89f256fcd7e957547fc9c02323c4d3544::path:packages/vfm" --partial
sh: 1: vfm: not found
```

</figure>
<figure>
<figcaption>このブランチの修正 <code><a href="a1fd162fefca440e72b24c85e11be35bbec4d0da">a1fd162</a></code></figcaption>

```shellsession
$ echo "# hello" | npx --yes --loglevel=silent "git+https://github.com/vivliostyle/vfm.git#a1fd162fefca440e72b24c85e11be35bbec4d0da::path:packages/vfm" --partial

<section class="level1">
  <h1 id="hello">hello</h1>
</section>
```

</figure>

サブディレクトリのパッケージを実行するにはかなり新しいnpm（11.10.0以降）が必要です。