### PR TITLE
fix: noUncheckedIndexedAccess下の型エラー解消

### DIFF
--- a/packages/vfm/src/plugins/footnotes.ts
+++ b/packages/vfm/src/plugins/footnotes.ts
@@ -91,6 +91,12 @@ type EndnoteBackReference = hast.Element & {
 const selectEndnoteBackReferences = (parent: hast.Element) =>
   selectAll(endnoteBackReferenceSelector, parent) as EndnoteBackReference[];
 
+/**
+ * Return a copy of `array` with only `key`'s values permuted to follow
+ * `compareFn`'s sort order; every other field stays in its original
+ * position.  Used to reshuffle one field across fixed slots without
+ * disturbing surrounding entries.
+ */
 function withSortedField<T extends Record<string, unknown>, K extends keyof T>(
   array: readonly T[],
   key: K,

--- a/packages/vfm/src/plugins/footnotes.ts
+++ b/packages/vfm/src/plugins/footnotes.ts
@@ -91,6 +91,17 @@ type EndnoteBackReference = hast.Element & {
 const selectEndnoteBackReferences = (parent: hast.Element) =>
   selectAll(endnoteBackReferenceSelector, parent) as EndnoteBackReference[];
 
+function withSortedField<T extends Record<string, unknown>, K extends keyof T>(
+  array: readonly T[],
+  key: K,
+  compareFn: (a: T, b: T) => number,
+): T[] {
+  const sortedValues = array.toSorted(compareFn);
+  return array.map(
+    (item, i) => ({ ...item, [key]: sortedValues[i]![key] }) as T,
+  );
+}
+
 /**
  * Create paired Pandoc transformer plugins that share duplicate-reference
  * state.  The first plugin rewrites endnote calls; the second rewrites
@@ -242,28 +253,29 @@ const createPandocTransformers = (): [unified.Plugin, unified.Plugin] => {
     const refIndexByElem = new Map<hast.Element, number>(
       resolved.map((r) => [r.elem, r.refIndex]),
     );
-    selectAll('section[role="doc-endnotes"] ol', root).forEach(
-      (ol: hast.Element) => {
-        const liSlots = ol.children
-          .map((child, index) =>
-            child.type === 'element' &&
-            child.tagName === 'li' &&
-            refIndexByElem.has(child)
-              ? index
-              : -1,
-          )
-          .filter((i) => i !== -1);
-        const sortedLis = liSlots
-          .map((i) => ol.children[i] as hast.Element)
-          .sort(
-            (a, b) =>
-              (refIndexByElem.get(a) ?? 0) - (refIndexByElem.get(b) ?? 0),
-          );
-        liSlots.forEach((slotIndex, i) => {
-          ol.children[slotIndex] = sortedLis[i];
-        });
-      },
-    );
+    selectAll('section[role="doc-endnotes"] ol', root).forEach((ol) => {
+      withSortedField(
+        ol.children.flatMap((child, i) =>
+          child.type === 'element' &&
+          child.tagName === 'li' &&
+          refIndexByElem.has(child)
+            ? [
+                {
+                  li: child,
+                  fn: (li: hast.Element) => {
+                    ol.children[i] = li;
+                  },
+                },
+              ]
+            : [],
+        ),
+        'li',
+        ({ li: a }, { li: b }) =>
+          (refIndexByElem.get(a) ?? 0) - (refIndexByElem.get(b) ?? 0),
+      ).forEach(({ fn, li }) => {
+        fn(li);
+      });
+    });
   };
 
   return [endnoteCallsToPandoc, endnoteAreasToPandoc];

--- a/packages/vfm/tests/footnotes.test.ts
+++ b/packages/vfm/tests/footnotes.test.ts
@@ -634,17 +634,22 @@ const issue129Md = `| Label     | Col |
 // order within `received`.  Catches partial fixes that relabel ids
 // correctly but leave the physical ordering of <ol>/<aside> reversed.
 const expectInOrder = (received: string, fragments: string[]) => {
-  const positions = fragments.map((f) => {
-    const pos = received.indexOf(f);
-    expect(pos, `fragment not found: ${f}`).toBeGreaterThanOrEqual(0);
-    return pos;
-  });
-  for (let i = 1; i < positions.length; i++) {
-    expect(
-      positions[i],
-      `fragments out of order at index ${i}: ${fragments[i]}`,
-    ).toBeGreaterThan(positions[i - 1]);
-  }
+  fragments
+    .map((fragment) => {
+      const pos = received.indexOf(fragment);
+      expect(pos, `fragment not found: ${fragment}`).toBeGreaterThanOrEqual(0);
+      return { fragment, pos };
+    })
+    .flatMap((curr, i, arr) => {
+      const prev = arr[i - 1];
+      return prev === undefined ? [] : [{ prev, curr }];
+    })
+    .forEach(({ prev, curr }, i) => {
+      expect(
+        curr.pos,
+        `fragments out of order at index ${i + 1}: ${curr.fragment}`,
+      ).toBeGreaterThan(prev.pos);
+    });
 };
 
 test('issue #129 pandoc: table footnote calls resolve to matching bodies', () => {


### PR DESCRIPTION
すみません、 #237 に #238 の変更を取り込まずにマージしたことで型チェックが通らないコードをmainに取り込んでしまいCIが落ちています。修正しました。