### PR TITLE
refactor: Convert figure plugin to mdast-to-hast handler and decouple from code

### DIFF
--- a/packages/vfm/src/index.ts
+++ b/packages/vfm/src/index.ts
@@ -28,7 +28,6 @@ export type {
 } from './revive-parse.js';
 export type {
   RehypeRawPlugin,
-  RehypeFigurePlugin,
   RehypeFootnotePlugin,
   RehypeReplacePlugin,
   RehypeDocumentPlugin,

--- a/packages/vfm/src/plugins/code.ts
+++ b/packages/vfm/src/plugins/code.ts
@@ -1,50 +1,64 @@
-import type { ElementContent as HastElementContent, Properties } from 'hast';
-import type { Code, Root } from 'mdast';
+import type * as hast from 'hast';
+import type * as mdastType from 'mdast';
 import type { Handler } from 'mdast-util-to-hast';
 import parseAttr from 'md-attr-parser';
 import refractor from 'refractor';
-import type { Node } from 'unist';
+import type * as unist from 'unist';
 import { u } from 'unist-builder';
 import { visit } from 'unist-util-visit';
-import { type FigureOptions, propertyToString } from './figure.js';
+import { type FigureOptions } from './figure.js';
+
+const isCodeNode = (
+  maybeMdastNode: unknown,
+): maybeMdastNode is mdastType.Code => {
+  if (!maybeMdastNode || typeof maybeMdastNode !== 'object') return false;
+  return (maybeMdastNode as { type?: unknown }).type === 'code';
+};
 
 /**
  * Module augmentation is global, so this single declaration applies
  * project-wide. Currently relied on by:
  *
- * - `code.ts` (this file): `hProperties`, `hChildren`
+ * - `code.ts` (this file): `hProperties`, `hChildren`, `figcaptionTitle`
  * - `section.ts`: `hProperties`, `hName`
  * - `slug.ts`: `hProperties.id`
  *
- * @todo Drop after upgrading to `mdast-util-to-hast@>=13`, which ships the
- *   same `Data` augmentation as a side effect import.
+ * @todo Drop the hast fields after upgrading to `mdast-util-to-hast@>=13`,
+ *   which ships the same `Data` augmentation as a side effect import.
  */
 declare module 'unist' {
   interface Data {
     hName?: string | undefined;
-    hProperties?: Properties | undefined;
-    hChildren?: HastElementContent[] | undefined;
+    hProperties?: hast.Properties | undefined;
+    hChildren?: hast.ElementContent[] | undefined;
+    /**
+     * Internal channel used by the code plugin to carry the caption text
+     * extracted from `lang:title`, `title=...` meta, or `{title="..."}` attr
+     * blocks through to the handler. Kept off `hProperties` so it never
+     * leaks into actual HTML attributes.
+     */
+    figcaptionTitle?: string | undefined;
   }
 }
 
-function getHProperties(node: Code): Properties {
-  return node.data?.hProperties ?? {};
-}
-function setHProperties(node: Code, props: Properties): void {
+function setHProperties(node: mdastType.Code, props: hast.Properties): void {
   node.data = { ...(node.data ?? {}), hProperties: props };
+}
+function setFigcaptionTitle(node: mdastType.Code, title: string): void {
+  node.data = { ...(node.data ?? {}), figcaptionTitle: title };
 }
 
 /**
- * Parse `lang:title` syntax and extract title to hProperties.
+ * Parse `lang:title` syntax and extract title to the figcaption channel.
  */
-function extractLangTitle(node: Code): void {
+function extractLangTitle(node: mdastType.Code): void {
   const match = /^(.+?):(.+)$/.exec(node.lang ?? '');
   if (!match) return;
 
   // The regex has exactly 2 capture groups
   const lang = match[1]!;
   const title = match[2]!;
-  setHProperties(node, { ...getHProperties(node), title });
+  setFigcaptionTitle(node, title);
   node.lang = lang;
   if (node.position?.end.offset) {
     node.position.end.offset -= title.length + 1;
@@ -86,7 +100,7 @@ function isInsideQuotes(meta: string, pos: number): boolean {
  */
 function findValidAttrBlock(
   meta: string,
-): { prop: Properties; eaten: string } | null {
+): { prop: hast.Properties; eaten: string } | null {
   let searchStart = 0;
   while (searchStart < meta.length) {
     const braceIndex = meta.indexOf('{', searchStart);
@@ -112,7 +126,7 @@ function findValidAttrBlock(
       Object.values(parsed.prop).some((v) => v !== undefined);
 
     if (parsed.eaten && parsed.eaten.startsWith('{') && hasValidAttrs) {
-      return { prop: parsed.prop as Properties, eaten: parsed.eaten };
+      return { prop: parsed.prop as hast.Properties, eaten: parsed.eaten };
     }
     searchStart = braceIndex + 1;
   }
@@ -122,33 +136,30 @@ function findValidAttrBlock(
 /**
  * Process meta string to extract title and `{...}` attributes.
  */
-function processMeta(node: Code): void {
+function processMeta(node: mdastType.Code): void {
   if (!node.meta) return;
 
   const metadata = parseMetadata(node.meta);
-
-  // copy title metadata for figure handler injecting figcaption
   if (metadata.title) {
-    setHProperties(node, { ...getHProperties(node), title: metadata.title });
+    setFigcaptionTitle(node, metadata.title);
   }
 
-  // Find and apply valid `{...}` attribute block
   const attrBlock = findValidAttrBlock(node.meta);
-  const existingTitle = getHProperties(node).title;
-
   if (attrBlock) {
-    setHProperties(node, {
-      ...(existingTitle ? { title: existingTitle } : {}),
-      ...attrBlock.prop,
-    });
+    // attrBlock can carry `title=...`; route it through the figcaption channel
+    // and keep only HTML attributes on hProperties.
+    const { title: blockTitle, ...rest } = attrBlock.prop;
+    if (typeof blockTitle === 'string') {
+      setFigcaptionTitle(node, blockTitle);
+    }
+    setHProperties(node, rest);
   } else {
-    // No valid `{...}` in meta, only keep title
-    setHProperties(node, existingTitle ? { title: existingTitle } : {});
+    setHProperties(node, {});
   }
 }
 
-export const mdast = () => (tree: Node) => {
-  visit(tree as Root, 'code', (node) => {
+export const mdast = () => (tree: unist.Node) => {
+  visit(tree as mdastType.Root, 'code', (node) => {
     /**
      * Workaround for remark-attr's "bad hack".
      * When meta is null, remark-attr parses code content as attributes.
@@ -167,31 +178,33 @@ export const mdast = () => (tree: Node) => {
       node.data.hChildren = refractor.highlight(
         node.value,
         node.lang,
-      ) as HastElementContent[];
+      ) as hast.ElementContent[];
     }
   });
 };
 
 export const handler =
   ({ assignIdToFigcaption = false }: FigureOptions = {}): Handler =>
-  (h, node) => {
+  (h, maybeMdastNode) => {
+    if (!isCodeNode(maybeMdastNode)) return undefined;
+    const node = maybeMdastNode;
     const value = node.value || '';
     const lang = node.lang ? node.lang.match(/^[^ \t]+(?=[ \t]|$)/) : 'text';
     const langClass = 'language-' + lang;
 
-    // Strip `title` from code element props; it becomes the figcaption text.
-    const hProps = { ...(node.data?.hProperties ?? {}) };
-    const title = hProps.title;
-    delete hProps.title;
+    const title = node.data?.figcaptionTitle;
+    const hProps: hast.Properties = { ...(node.data?.hProperties ?? {}) };
 
-    // Merge language-* class with hProperties.class if present
+    // Merge language-* class with hProperties.class if present. `hProps.class`
+    // can theoretically be any `Properties[key]` value; coerce to string in
+    // the non-array branch so the resulting className stays `(string|number)[]`.
     const hClass = hProps.class;
-    const className = hClass
-      ? [langClass, ...(Array.isArray(hClass) ? hClass : [hClass])]
+    const className: (string | number)[] = hClass
+      ? [langClass, ...(Array.isArray(hClass) ? hClass : [String(hClass)])]
       : [langClass];
 
     const preProps = { className: [langClass] };
-    const codeProps = { ...hProps, className };
+    const codeProps: hast.Properties = { ...hProps, className };
     // Use hChildren for syntax highlighting if available, otherwise plain text
     const children = node.data?.hChildren ?? [u('text', value)];
 
@@ -201,16 +214,14 @@ export const handler =
       ]);
     }
 
-    const figcaptionProps: Properties = {};
+    const figcaptionProps: hast.Properties = {};
     if (assignIdToFigcaption && codeProps.id) {
       figcaptionProps.id = codeProps.id;
       delete codeProps.id;
     }
 
     return h(node.position, 'figure', { class: langClass }, [
-      h({ type: 'element' }, 'figcaption', figcaptionProps, [
-        u('text', propertyToString(title)),
-      ]),
+      h({ type: 'element' }, 'figcaption', figcaptionProps, [u('text', title)]),
       h(node.position, 'pre', preProps, [
         h(node.position, 'code', codeProps, children),
       ]),

--- a/packages/vfm/src/plugins/code.ts
+++ b/packages/vfm/src/plugins/code.ts
@@ -6,6 +6,7 @@ import refractor from 'refractor';
 import type { Node } from 'unist';
 import { u } from 'unist-builder';
 import { visit } from 'unist-util-visit';
+import { type FigureOptions, propertyToString } from './figure.js';
 
 /**
  * Module augmentation is global, so this single declaration applies
@@ -171,24 +172,47 @@ export const mdast = () => (tree: Node) => {
   });
 };
 
-export const handler: Handler = (h, node) => {
-  const value = node.value || '';
-  const lang = node.lang ? node.lang.match(/^[^ \t]+(?=[ \t]|$)/) : 'text';
-  const langClass = 'language-' + lang;
+export const handler =
+  ({ assignIdToFigcaption = false }: FigureOptions = {}): Handler =>
+  (h, node) => {
+    const value = node.value || '';
+    const lang = node.lang ? node.lang.match(/^[^ \t]+(?=[ \t]|$)/) : 'text';
+    const langClass = 'language-' + lang;
 
-  // Merge language-* class with hProperties.class if present
-  const hProps = node.data?.hProperties ?? {};
-  const hClass = hProps.class;
-  const className = hClass
-    ? [langClass, ...(Array.isArray(hClass) ? hClass : [hClass])]
-    : [langClass];
+    // Strip `title` from code element props; it becomes the figcaption text.
+    const hProps = { ...(node.data?.hProperties ?? {}) };
+    const title = hProps.title;
+    delete hProps.title;
 
-  const preProps = { className: [langClass] };
-  const codeProps = { ...hProps, className };
-  // Use hChildren for syntax highlighting if available, otherwise plain text
-  const children = node.data?.hChildren ?? [u('text', value)];
+    // Merge language-* class with hProperties.class if present
+    const hClass = hProps.class;
+    const className = hClass
+      ? [langClass, ...(Array.isArray(hClass) ? hClass : [hClass])]
+      : [langClass];
 
-  return h(node.position, 'pre', preProps, [
-    h(node.position, 'code', codeProps, children),
-  ]);
-};
+    const preProps = { className: [langClass] };
+    const codeProps = { ...hProps, className };
+    // Use hChildren for syntax highlighting if available, otherwise plain text
+    const children = node.data?.hChildren ?? [u('text', value)];
+
+    if (!title) {
+      return h(node.position, 'pre', preProps, [
+        h(node.position, 'code', codeProps, children),
+      ]);
+    }
+
+    const figcaptionProps: Properties = {};
+    if (assignIdToFigcaption && codeProps.id) {
+      figcaptionProps.id = propertyToString(codeProps.id);
+      delete codeProps.id;
+    }
+
+    return h(node.position, 'figure', { class: langClass }, [
+      h({ type: 'element' }, 'figcaption', figcaptionProps, [
+        u('text', propertyToString(title)),
+      ]),
+      h(node.position, 'pre', preProps, [
+        h(node.position, 'code', codeProps, children),
+      ]),
+    ]);
+  };

--- a/packages/vfm/src/plugins/code.ts
+++ b/packages/vfm/src/plugins/code.ts
@@ -203,7 +203,7 @@ export const handler =
 
     const figcaptionProps: Properties = {};
     if (assignIdToFigcaption && codeProps.id) {
-      figcaptionProps.id = propertyToString(codeProps.id);
+      figcaptionProps.id = codeProps.id;
       delete codeProps.id;
     }
 

--- a/packages/vfm/src/plugins/code.ts
+++ b/packages/vfm/src/plugins/code.ts
@@ -6,7 +6,11 @@ import refractor from 'refractor';
 import type * as unist from 'unist';
 import { u } from 'unist-builder';
 import { visit } from 'unist-util-visit';
-import { type FigureOptions } from './figure.js';
+
+export type CodeOptions = {
+  /** Assign ID to figcaption instead of the `<code>` element. */
+  assignIdToFigcaption?: boolean | undefined;
+};
 
 const isCodeNode = (
   maybeMdastNode: unknown,
@@ -184,7 +188,7 @@ export const mdast = () => (tree: unist.Node) => {
 };
 
 export const handler =
-  ({ assignIdToFigcaption = false }: FigureOptions = {}): Handler =>
+  ({ assignIdToFigcaption = false }: CodeOptions = {}): Handler =>
   (h, maybeMdastNode) => {
     if (!isCodeNode(maybeMdastNode)) return undefined;
     const node = maybeMdastNode;

--- a/packages/vfm/src/plugins/figure.ts
+++ b/packages/vfm/src/plugins/figure.ts
@@ -1,10 +1,9 @@
-import type { Element, Properties, Root } from 'hast';
-import { isElement as is } from 'hast-util-is-element';
-import { h } from 'hastscript';
-import type { Node, Parent } from 'unist';
-import { visit } from 'unist-util-visit';
+import type { Element, Properties } from 'hast';
+import type { Image, Paragraph } from 'mdast';
+import { type H, all } from 'mdast-util-to-hast';
+import { u } from 'unist-builder';
 
-const propertyToString = (
+export const propertyToString = (
   property: NonNullable<Element['properties']>[string],
 ) => {
   return typeof property === 'string' || typeof property === 'number'
@@ -22,99 +21,67 @@ export type FigureOptions = {
   assignIdToFigcaption?: boolean | undefined;
 };
 
-/**
- * Move ID from source element to target properties if assignIdToFigcaption is enabled.
- * @param source Element to move ID from (img or code).
- * @param targetProps Properties object to receive the ID.
- * @param options Figure options.
- */
-const moveIdToFigcaption = (
-  source: Element,
-  targetProps: Properties,
-  options: FigureOptions,
-) => {
-  if (options.assignIdToFigcaption && source.properties?.id) {
-    targetProps.id = propertyToString(source.properties.id);
-    delete source.properties.id;
-  }
+const isFigureImage = (child: unknown): child is Image & { alt: string } => {
+  if (!child || typeof child !== 'object') return false;
+  const node = child as { type?: unknown; alt?: unknown };
+  return node.type === 'image' && typeof node.alt === 'string' && !!node.alt;
 };
 
 /**
- * Wrap the single line `<img>` in `<figure>` and generate `<figcaption>` from the `alt` attribute.
- *
- * A single line `<img>` is a child of `<p>` with no sibling elements. Also, `<figure>` cannot be a child of `<p>`. So convert the parent `<p>` to `<figure>`.
- * @param img `<img>` tag.
- * @param parent `<p>` tag.
- * @param options Figure options.
+ * Predicate: a paragraph qualifies as a figure when it contains exactly one
+ * image child with non-empty `alt`. Exposed so callers composing their own
+ * `paragraph` handler (e.g. for CJK whitespace handling, indent control) can
+ * delegate the figure case without re-implementing this rule.
  */
-const wrapFigureImg = (
-  img: Element,
-  parent: Element,
-  options: FigureOptions,
-) => {
-  if (!(img.properties && parent.properties)) {
-    return;
-  }
+export const isFigureParagraph = (
+  node: unknown,
+): node is Paragraph & { children: [Image & { alt: string }] } => {
+  if (!node || typeof node !== 'object') return false;
+  const n = node as { type?: unknown; children?: unknown };
+  if (n.type !== 'paragraph') return false;
+  if (!Array.isArray(n.children) || n.children.length !== 1) return false;
+  return isFigureImage(n.children[0]);
+};
 
-  parent.tagName = 'figure';
+/**
+ * Build a `<figure>` element from a paragraph that satisfies
+ * {@link isFigureParagraph}. Returns `undefined` for any other node, so
+ * callers can fall through to their own default `<p>` rendering:
+ *
+ * ```ts
+ * paragraph: (h, node) =>
+ *   buildFigure(h, node, options) ?? h(node, 'p', all(h, node));
+ * ```
+ */
+export const buildFigure = (
+  h: H,
+  node: unknown,
+  {
+    imgFigcaptionOrder = 'img-figcaption',
+    assignIdToFigcaption = false,
+  }: FigureOptions = {},
+): Element | undefined => {
+  if (!isFigureParagraph(node)) return undefined;
+
+  const converted = all(h, node) as Element[];
+  const img = converted[0];
+  if (!img || !img.properties) return undefined;
 
   const figcaptionProps: Properties = { 'aria-hidden': 'true' };
-  moveIdToFigcaption(img, figcaptionProps, options);
-
-  const figcaption = h(
-    'figcaption',
-    figcaptionProps,
-    propertyToString(img.properties.alt),
-  );
-
-  if (options.imgFigcaptionOrder === 'figcaption-img') {
-    parent.children.unshift(figcaption);
-  } else {
-    parent.children.push(figcaption);
+  if (assignIdToFigcaption && img.properties.id) {
+    figcaptionProps.id = propertyToString(img.properties.id);
+    delete img.properties.id;
   }
-};
 
-export const hast = ({
-  imgFigcaptionOrder = 'img-figcaption',
-  assignIdToFigcaption = false,
-}: FigureOptions = {}) => {
-  const options: FigureOptions = { imgFigcaptionOrder, assignIdToFigcaption };
-  return (tree: Node) => {
-    visit(tree as Root, 'element', (node, index, parent) => {
-      // handle captioned code block
-      const maybeCode = node.children?.[0] as Element | undefined;
-      if (
-        is(node, 'pre') &&
-        maybeCode?.properties &&
-        maybeCode.properties.title
-      ) {
-        const maybeTitle = maybeCode.properties.title;
-        delete maybeCode.properties.title;
-        if (Array.isArray(maybeCode.properties.className)) {
-          const figcaptionProps: Properties = {};
-          moveIdToFigcaption(maybeCode, figcaptionProps, options);
+  const altText = propertyToString(img.properties.alt);
+  const figcaption = h({ type: 'element' }, 'figcaption', figcaptionProps, [
+    u('text', altText),
+  ]) as Element;
 
-          (parent as Parent).children[index as number] = h(
-            'figure',
-            { class: maybeCode.properties.className[0] },
-            h('figcaption', figcaptionProps, propertyToString(maybeTitle)),
-            node,
-          );
-        }
+  const figureChildren =
+    imgFigcaptionOrder === 'figcaption-img'
+      ? [figcaption, img]
+      : [img, figcaption];
 
-        return;
-      }
-
-      // handle captioned and single line (like a block) img
-      if (
-        is(node, 'img') &&
-        node.properties?.alt &&
-        parent &&
-        parent.tagName === 'p' &&
-        parent.children.length === 1
-      ) {
-        wrapFigureImg(node, parent as Element, options);
-      }
-    });
-  };
+  return h(node, 'figure', figureChildren) as Element;
 };

--- a/packages/vfm/src/plugins/figure.ts
+++ b/packages/vfm/src/plugins/figure.ts
@@ -1,17 +1,7 @@
-import type { Element, Properties } from 'hast';
-import type { Image, Paragraph } from 'mdast';
+import type * as hast from 'hast';
+import type * as mdast from 'mdast';
 import { type H, all } from 'mdast-util-to-hast';
 import { u } from 'unist-builder';
-
-export const propertyToString = (
-  property: NonNullable<Element['properties']>[string],
-) => {
-  return typeof property === 'string' || typeof property === 'number'
-    ? String(property) // <tag prop="foo" /> || <tag prop=42 />
-    : Array.isArray(property)
-      ? property.map(String).join(' ') // <tag prop="foo 42 bar" />
-      : ''; // <tag /> || <tag prop />
-};
 
 export type ImgFigcaptionOrder = 'img-figcaption' | 'figcaption-img';
 export type FigureOptions = {
@@ -21,9 +11,11 @@ export type FigureOptions = {
   assignIdToFigcaption?: boolean | undefined;
 };
 
-const isFigureImage = (child: unknown): child is Image & { alt: string } => {
-  if (!child || typeof child !== 'object') return false;
-  const node = child as { type?: unknown; alt?: unknown };
+const isFigureImage = (
+  maybeMdastNode: unknown,
+): maybeMdastNode is mdast.Image & { alt: string } => {
+  if (!maybeMdastNode || typeof maybeMdastNode !== 'object') return false;
+  const node = maybeMdastNode as { type?: unknown; alt?: unknown };
   return node.type === 'image' && typeof node.alt === 'string' && !!node.alt;
 };
 
@@ -34,10 +26,12 @@ const isFigureImage = (child: unknown): child is Image & { alt: string } => {
  * delegate the figure case without re-implementing this rule.
  */
 export const isFigureParagraph = (
-  node: unknown,
-): node is Paragraph & { children: [Image & { alt: string }] } => {
-  if (!node || typeof node !== 'object') return false;
-  const n = node as { type?: unknown; children?: unknown };
+  maybeMdastNode: unknown,
+): maybeMdastNode is mdast.Paragraph & {
+  children: [mdast.Image & { alt: string }];
+} => {
+  if (!maybeMdastNode || typeof maybeMdastNode !== 'object') return false;
+  const n = maybeMdastNode as { type?: unknown; children?: unknown };
   if (n.type !== 'paragraph') return false;
   if (!Array.isArray(n.children) || n.children.length !== 1) return false;
   return isFigureImage(n.children[0]);
@@ -55,33 +49,33 @@ export const isFigureParagraph = (
  */
 export const buildFigure = (
   h: H,
-  node: unknown,
+  maybeMdastNode: unknown,
   {
     imgFigcaptionOrder = 'img-figcaption',
     assignIdToFigcaption = false,
   }: FigureOptions = {},
-): Element | undefined => {
-  if (!isFigureParagraph(node)) return undefined;
+): hast.Element | undefined => {
+  if (!isFigureParagraph(maybeMdastNode)) return undefined;
 
-  const converted = all(h, node) as Element[];
+  const converted = all(h, maybeMdastNode);
   const img = converted[0];
-  if (!img || !img.properties) return undefined;
+  if (img?.type !== 'element') return undefined;
 
-  const figcaptionProps: Properties = { 'aria-hidden': 'true' };
-  if (assignIdToFigcaption && img.properties.id) {
+  const figcaptionProps: hast.Properties = { 'aria-hidden': 'true' };
+  if (assignIdToFigcaption && img.properties && img.properties.id) {
     figcaptionProps.id = img.properties.id;
     delete img.properties.id;
   }
 
-  const altText = propertyToString(img.properties.alt);
+  const altText = maybeMdastNode.children[0].alt;
   const figcaption = h({ type: 'element' }, 'figcaption', figcaptionProps, [
     u('text', altText),
-  ]) as Element;
+  ]);
 
   const figureChildren =
     imgFigcaptionOrder === 'figcaption-img'
       ? [figcaption, img]
       : [img, figcaption];
 
-  return h(node, 'figure', figureChildren) as Element;
+  return h(maybeMdastNode, 'figure', figureChildren);
 };

--- a/packages/vfm/src/plugins/figure.ts
+++ b/packages/vfm/src/plugins/figure.ts
@@ -69,7 +69,7 @@ export const buildFigure = (
 
   const figcaptionProps: Properties = { 'aria-hidden': 'true' };
   if (assignIdToFigcaption && img.properties.id) {
-    figcaptionProps.id = propertyToString(img.properties.id);
+    figcaptionProps.id = img.properties.id;
     delete img.properties.id;
   }
 

--- a/packages/vfm/src/plugins/options.ts
+++ b/packages/vfm/src/plugins/options.ts
@@ -1,3 +1,4 @@
+import type { CodeOptions } from './code.js';
 import type { DocumentOptions } from './document.js';
 import type { FigureOptions } from './figure.js';
 import type { FootnoteOptions } from './footnotes.js';
@@ -23,4 +24,5 @@ export type SerializablePluginOptions = LineBreaksOptions &
   Pick<DocumentOptions, 'partial'> &
   FormatOptions &
   FigureOptions &
+  CodeOptions &
   FootnoteOptions;

--- a/packages/vfm/src/revive-rehype.ts
+++ b/packages/vfm/src/revive-rehype.ts
@@ -1,7 +1,7 @@
 import { type Handler, all } from 'mdast-util-to-hast';
 import raw from 'rehype-raw';
 import unified from 'unified';
-import { handler as code } from './plugins/code.js';
+import { handler as code, type CodeOptions } from './plugins/code.js';
 import { mdast as doc, type DocumentOptions } from './plugins/document.js';
 import { buildFigure, type FigureOptions } from './plugins/figure.js';
 import {
@@ -20,6 +20,7 @@ import { handler as ruby } from './plugins/ruby.js';
 import { brand, partial } from './utils.js';
 
 export type ReviveRehypeOptions = FigureOptions &
+  CodeOptions &
   FootnoteOptions &
   ReplaceOptions &
   DocumentOptions &

--- a/packages/vfm/src/revive-rehype.ts
+++ b/packages/vfm/src/revive-rehype.ts
@@ -1,8 +1,9 @@
+import { type Handler, all } from 'mdast-util-to-hast';
 import raw from 'rehype-raw';
 import unified from 'unified';
 import { handler as code } from './plugins/code.js';
 import { mdast as doc, type DocumentOptions } from './plugins/document.js';
-import { hast as figure, type FigureOptions } from './plugins/figure.js';
+import { buildFigure, type FigureOptions } from './plugins/figure.js';
 import {
   createFootnotePlugin,
   type FootnoteOptions,
@@ -28,11 +29,6 @@ export type ReviveRehypeOptions = FigureOptions &
 declare const rehypeRawPluginBrand: unique symbol;
 export type RehypeRawPlugin = unified.Pluggable & {
   [rehypeRawPluginBrand]: unknown;
-};
-
-declare const rehypeFigurePluginBrand: unique symbol;
-export type RehypeFigurePlugin = unified.Pluggable & {
-  [rehypeFigurePluginBrand]: unknown;
 };
 
 declare const rehypeFootnotePluginBrand: unique symbol;
@@ -75,12 +71,13 @@ export const reviveRehype = (options: ReviveRehypeOptions) => {
       displayMath,
       inlineMath,
       ruby,
-      code,
+      code: code(options),
+      paragraph: ((h, node) =>
+        buildFigure(h, node, options) ?? h(node, 'p', all(h, node))) as Handler,
       ...footnoteHandlers,
     } as const,
     hastPlugins: [
       brand<RehypeRawPlugin>(raw),
-      brand<RehypeFigurePlugin>(partial(figure, options)),
       brand<RehypeFootnotePlugin>(footnoteTransformer),
       brand<RehypeReplacePlugin>(partial(replace, options)),
       brand<RehypeDocumentPlugin>(partial(doc, options)),

--- a/packages/vfm/tests/edit-plugins.test.ts
+++ b/packages/vfm/tests/edit-plugins.test.ts
@@ -63,26 +63,32 @@ describe('editPlugins', () => {
   });
 
   test('editor can drop a hast plugin entirely', () => {
-    // Confirm the figure plugin (slot index 1 in hastPlugins) wraps lone images
-    // by default…
-    const withDefault = String(
-      VFM(baseOptions).processSync('![alt](pic.png)\n'),
-    );
-    expect(withDefault).toContain('<figure>');
-
-    // …and is gone when removed via editPlugins.
-    const withoutFigure = String(
-      VFM({
-        ...baseOptions,
-        editPlugins: (plugins) => {
-          // keep comment between commas
-          // prettier-ignore
-          const [raw, /* figure */ , ...rest] = plugins.hastPlugins;
-          return { ...plugins, hastPlugins: [raw, ...rest] };
+    const replaceOptions = {
+      ...baseOptions,
+      replace: [
+        {
+          test: /foo/,
+          match: () => 'BAR',
         },
-      }).processSync('![alt](pic.png)\n'),
+      ],
+    };
+
+    // Confirm the replace plugin rewrites text by default...
+    const withDefault = String(VFM(replaceOptions).processSync('foo\n'));
+    expect(withDefault).toContain('BAR');
+
+    // ...and is gone when removed via editPlugins. Slot order is
+    // [raw, footnote, replace, doc, math, format].
+    const withoutReplace = String(
+      VFM({
+        ...replaceOptions,
+        editPlugins: (plugins) => {
+          const [raw, footnote /* replace */, , ...rest] = plugins.hastPlugins;
+          return { ...plugins, hastPlugins: [raw, footnote, ...rest] };
+        },
+      }).processSync('foo\n'),
     );
-    expect(withoutFigure).not.toContain('<figure>');
+    expect(withoutReplace).not.toContain('BAR');
   });
 
   test('editor can prepend an mdast plugin that observes parsed nodes', () => {
@@ -108,46 +114,52 @@ describe('editPlugins', () => {
     expect(headings).toEqual(['alpha', 'beta']);
   });
 
-  test('plugin injected between figure and footnote sees post-figure tree', () => {
+  test('plugin injected around replace sees pre/post-replacement tree', () => {
     const observe =
-      (record: { sawFigure: boolean }): unified.Plugin =>
+      (record: { sawReplaced: boolean }): unified.Plugin =>
       () =>
       (tree) => {
-        visit(tree as hast.Root, 'element', (node) => {
-          if (node.tagName === 'figure') record.sawFigure = true;
+        visit(tree as hast.Root, 'text', (node) => {
+          if (node.value.includes('BAR')) record.sawReplaced = true;
         });
       };
 
-    const beforeFigure = { sawFigure: false };
-    const afterFigure = { sawFigure: false };
+    const beforeReplace = { sawReplaced: false };
+    const afterReplace = { sawReplaced: false };
 
     String(
       VFM({
         ...baseOptions,
+        replace: [
+          {
+            test: /foo/,
+            match: () => 'BAR',
+          },
+        ],
         editPlugins: ({ mdastPlugins, mdastToHastHandlers, hastPlugins }) => {
           // Tuple destructure binds each slot by its brand type, letting
           // the editor splice between specific plugins without index
           // arithmetic.
-          const [raw, figure, footnote, ...rest] = hastPlugins;
+          const [raw, footnote, replace, ...rest] = hastPlugins;
           return {
             mdastPlugins,
             mdastToHastHandlers,
             hastPlugins: [
               raw,
-              observe(beforeFigure),
-              figure,
-              observe(afterFigure),
               footnote,
+              observe(beforeReplace),
+              replace,
+              observe(afterReplace),
               ...rest,
             ],
           };
         },
-      }).processSync('![alt](pic.png)\n'),
+      }).processSync('foo\n'),
     );
 
-    // figure plugin wraps lone images in <figure>; observers placed before and
-    // after it disagree on whether the wrapper is visible.
-    expect(beforeFigure.sawFigure).toBe(false);
-    expect(afterFigure.sawFigure).toBe(true);
+    // replace rewrites `foo` -> `BAR`; observers placed before and after it
+    // disagree on whether the replacement is visible.
+    expect(beforeReplace.sawReplaced).toBe(false);
+    expect(afterReplace.sawReplaced).toBe(true);
   });
 });

--- a/packages/vfm/tests/edit-plugins.test.ts
+++ b/packages/vfm/tests/edit-plugins.test.ts
@@ -83,7 +83,8 @@ describe('editPlugins', () => {
       VFM({
         ...replaceOptions,
         editPlugins: (plugins) => {
-          const [raw, footnote /* replace */, , ...rest] = plugins.hastPlugins;
+          const [raw, footnote, _replace, ...rest] = plugins.hastPlugins;
+          void _replace;
           return { ...plugins, hastPlugins: [raw, footnote, ...rest] };
         },
       }).processSync('foo\n'),


### PR DESCRIPTION
現在figureの生成は、mdast→hast変換後のhast transformとして定義されています。また、codeプラグインが一旦嘘の`<pre><code title="caption">`を書き出し、figureプラグインがそれを後処理してfigcaptionにするといういまいちな構造になっていました。

このPRでは、キャプションつき画像のみパラグラフからのfigureの生成をtoHast変換時のハンドラとして再定義します。またcodeのキャプションはhPropertiesに混入させずに、自前のaugmentationで運び、codeハンドラ内で処理させます。`assignIdToFigcaption`オプションは2つのモジュールから独立にexportし、figureとcodeの依存を切ります。