### PR TITLE
feat: add captionlessImagePolicy to control empty-alt image output

### DIFF
--- a/packages/vfm/src/index.ts
+++ b/packages/vfm/src/index.ts
@@ -132,6 +132,7 @@ export function VFM(
     math,
     imgFigcaptionOrder,
     assignIdToFigcaption,
+    captionlessImagePolicy,
     footnote,
     editPlugins = (plugins) => plugins,
   }: StringifyMarkdownOptions = {},
@@ -159,6 +160,9 @@ export function VFM(
     if (metadata.vfm.assignIdToFigcaption !== undefined) {
       assignIdToFigcaption = metadata.vfm.assignIdToFigcaption;
     }
+    if (metadata.vfm.captionlessImagePolicy !== undefined) {
+      captionlessImagePolicy = metadata.vfm.captionlessImagePolicy;
+    }
     if (metadata.vfm.footnote !== undefined) {
       footnote = metadata.vfm.footnote;
     }
@@ -169,6 +173,7 @@ export function VFM(
     ...html({
       imgFigcaptionOrder,
       assignIdToFigcaption,
+      captionlessImagePolicy,
       footnote,
       replace,
       partial,

--- a/packages/vfm/src/plugins/code.ts
+++ b/packages/vfm/src/plugins/code.ts
@@ -193,7 +193,8 @@ export const handler =
     if (!isCodeNode(maybeMdastNode)) return undefined;
     const node = maybeMdastNode;
     const value = node.value || '';
-    const lang = node.lang ? node.lang.match(/^[^ \t]+(?=[ \t]|$)/) : 'text';
+    const langMatch = node.lang?.match(/^[^ \t]+(?=[ \t]|$)/);
+    const lang = langMatch?.[0] ?? 'text';
     const langClass = 'language-' + lang;
 
     const title = node.data?.figcaptionTitle;

--- a/packages/vfm/src/plugins/code.ts
+++ b/packages/vfm/src/plugins/code.ts
@@ -191,6 +191,7 @@ export const handler =
   ({ assignIdToFigcaption = false }: CodeOptions = {}): Handler =>
   (h, maybeMdastNode) => {
     if (!isCodeNode(maybeMdastNode)) return undefined;
+
     const node = maybeMdastNode;
     const value = node.value || '';
     const langMatch = node.lang?.match(/^[^ \t]+(?=[ \t]|$)/);

--- a/packages/vfm/src/plugins/figure.ts
+++ b/packages/vfm/src/plugins/figure.ts
@@ -30,36 +30,38 @@ export type FigureOptions = {
   captionlessImagePolicy?: CaptionlessImagePolicy | undefined;
 };
 
-const isFigureImage = (
+const isImageNode = (
   maybeMdastNode: unknown,
-): maybeMdastNode is mdast.Image & { alt: string } => {
+): maybeMdastNode is mdast.Image => {
   if (!maybeMdastNode || typeof maybeMdastNode !== 'object') return false;
-  const node = maybeMdastNode as { type?: unknown; alt?: unknown };
-  return node.type === 'image' && typeof node.alt === 'string' && !!node.alt;
+  return (maybeMdastNode as { type?: unknown }).type === 'image';
 };
 
 /**
- * Predicate: a paragraph qualifies as a figure when it contains exactly one
- * image child with non-empty `alt`. Exposed so callers composing their own
- * `paragraph` handler (e.g. for CJK whitespace handling, indent control) can
- * delegate the figure case without re-implementing this rule.
+ * Predicate: a paragraph is figure-shaped when it contains exactly one image
+ * child. This is a pure structural check and does not consider `alt` content.
+ * Whether such a paragraph should actually become a `<figure>` is a policy
+ * decision left to {@link buildFigure}, which weighs `alt` and
+ * {@link FigureOptions} together.
+ *
+ * Exposed so callers composing their own `paragraph` handler (e.g. for CJK
+ * whitespace handling, indent control) can inspect figure candidacy.
  */
 export const isFigureParagraph = (
   maybeMdastNode: unknown,
-): maybeMdastNode is mdast.Paragraph & {
-  children: [mdast.Image & { alt: string }];
-} => {
+): maybeMdastNode is mdast.Paragraph & { children: [mdast.Image] } => {
   if (!maybeMdastNode || typeof maybeMdastNode !== 'object') return false;
   const n = maybeMdastNode as { type?: unknown; children?: unknown };
   if (n.type !== 'paragraph') return false;
   if (!Array.isArray(n.children) || n.children.length !== 1) return false;
-  return isFigureImage(n.children[0]);
+  return isImageNode(n.children[0]);
 };
 
 /**
- * Build a `<figure>` element from a paragraph that satisfies
- * {@link isFigureParagraph}. Returns `undefined` for any other node, so
- * callers can fall through to their own default `<p>` rendering:
+ * Build a `<figure>` element from a figure-shaped paragraph. Returns
+ * `undefined` when the node is not figure-shaped, or when its image lacks an
+ * `alt` and `captionlessImagePolicy` is `'paragraph'` (the default). Callers
+ * compose this with their own `<p>` fallback:
  *
  * ```ts
  * paragraph: (h, node) =>
@@ -72,13 +74,21 @@ export const buildFigure = (
   {
     imgFigcaptionOrder = 'img-figcaption',
     assignIdToFigcaption = false,
+    captionlessImagePolicy = 'paragraph',
   }: FigureOptions = {},
 ): hast.Element | undefined => {
   if (!isFigureParagraph(maybeMdastNode)) return undefined;
 
+  const hasCaption = !!maybeMdastNode.children[0].alt;
+  if (!hasCaption && captionlessImagePolicy === 'paragraph') return undefined;
+
   const converted = all(h, maybeMdastNode);
   const img = converted[0];
   if (img?.type !== 'element') return undefined;
+
+  if (!hasCaption && captionlessImagePolicy === 'figure') {
+    return h(maybeMdastNode, 'figure', [img]);
+  }
 
   const figcaptionProps: hast.Properties = { 'aria-hidden': 'true' };
   if (assignIdToFigcaption && img.properties && img.properties.id) {
@@ -86,7 +96,7 @@ export const buildFigure = (
     delete img.properties.id;
   }
 
-  const altText = maybeMdastNode.children[0].alt;
+  const altText = maybeMdastNode.children[0].alt ?? '';
   const figcaption = h({ type: 'element' }, 'figcaption', figcaptionProps, [
     u('text', altText),
   ]);

--- a/packages/vfm/src/plugins/figure.ts
+++ b/packages/vfm/src/plugins/figure.ts
@@ -4,11 +4,30 @@ import { type H, all } from 'mdast-util-to-hast';
 import { u } from 'unist-builder';
 
 export type ImgFigcaptionOrder = 'img-figcaption' | 'figcaption-img';
+
+/**
+ * Rendering policy for an image-only paragraph whose `alt` is empty
+ * (e.g. `![](url)`). Controls the output structure independently of the
+ * captioned case, which always renders as `<figure><img><figcaption>...`.
+ *
+ * - `'paragraph'`: keep `<p><img></p>` (default; backward compatible).
+ * - `'figure'`: emit `<figure><img></figure>` with no figcaption slot.
+ * - `'figure-with-figcaption'`: emit `<figure><img><figcaption></figcaption></figure>`
+ *   so CSS counters and `imgFigcaptionOrder`/`assignIdToFigcaption` apply
+ *   uniformly across captioned and captionless cases.
+ */
+export type CaptionlessImagePolicy =
+  | 'paragraph'
+  | 'figure'
+  | 'figure-with-figcaption';
+
 export type FigureOptions = {
   /** Order of img and figcaption elements in figure. */
   imgFigcaptionOrder?: ImgFigcaptionOrder | undefined;
   /** Assign ID to figcaption instead of img/code. */
   assignIdToFigcaption?: boolean | undefined;
+  /** How to render an image-only paragraph whose `alt` is empty. */
+  captionlessImagePolicy?: CaptionlessImagePolicy | undefined;
 };
 
 const isFigureImage = (

--- a/packages/vfm/src/plugins/metadata.ts
+++ b/packages/vfm/src/plugins/metadata.ts
@@ -304,6 +304,12 @@ const readSettings = (data: any): VFMSettings => {
       typeof data.assignIdToFigcaption === 'boolean'
         ? data.assignIdToFigcaption
         : false,
+    captionlessImagePolicy:
+      data.captionlessImagePolicy === 'paragraph' ||
+      data.captionlessImagePolicy === 'figure' ||
+      data.captionlessImagePolicy === 'figure-with-figcaption'
+        ? data.captionlessImagePolicy
+        : undefined,
     footnote: readFootnoteOption(data.footnote),
   };
 };

--- a/packages/vfm/tests/figure.test.ts
+++ b/packages/vfm/tests/figure.test.ts
@@ -35,6 +35,40 @@ test(
 );
 
 test(
+  "captionlessImagePolicy: 'figure' wraps image without figcaption",
+  buildProcessorTestingCode(
+    `![](./img.png)`,
+    stripIndent`
+    root[1]
+    └─0 paragraph[1]
+        └─0 image
+              title: null
+              url: "./img.png"
+              alt: null
+    `,
+    `<figure><img src="./img.png"></figure>`,
+    { captionlessImagePolicy: 'figure' },
+  ),
+);
+
+test(
+  "captionlessImagePolicy: 'figure-with-figcaption' emits empty figcaption",
+  buildProcessorTestingCode(
+    `![](./img.png)`,
+    stripIndent`
+    root[1]
+    └─0 paragraph[1]
+        └─0 image
+              title: null
+              url: "./img.png"
+              alt: null
+    `,
+    `<figure><img src="./img.png"><figcaption aria-hidden="true"></figcaption></figure>`,
+    { captionlessImagePolicy: 'figure-with-figcaption' },
+  ),
+);
+
+test(
   'Only single line',
   buildProcessorTestingCode(
     stripIndent`

--- a/packages/vfm/tests/figure.test.ts
+++ b/packages/vfm/tests/figure.test.ts
@@ -69,6 +69,119 @@ test(
 );
 
 test(
+  "captionlessImagePolicy: 'figure' does not promote inline image",
+  buildProcessorTestingCode(
+    `text ![](./img.png) text`,
+    stripIndent`
+    root[1]
+    └─0 paragraph[3]
+        ├─0 text "text "
+        ├─1 image
+        │     title: null
+        │     url: "./img.png"
+        │     alt: null
+        └─2 text " text"
+    `,
+    `<p>text <img src="./img.png"> text</p>`,
+    { captionlessImagePolicy: 'figure' },
+  ),
+);
+
+test(
+  "captionlessImagePolicy: 'figure' does not affect captioned image",
+  buildProcessorTestingCode(
+    `![caption](./img.png)`,
+    stripIndent`
+    root[1]
+    └─0 paragraph[1]
+        └─0 image
+              title: null
+              url: "./img.png"
+              alt: "caption"
+    `,
+    `<figure><img src="./img.png" alt="caption"><figcaption aria-hidden="true">caption</figcaption></figure>`,
+    { captionlessImagePolicy: 'figure' },
+  ),
+);
+
+test(
+  "captionlessImagePolicy: 'figure' with assignIdToFigcaption keeps ID on img",
+  buildProcessorTestingCode(
+    `![](./img.png){#fig1}`,
+    stripIndent`
+    root[1]
+    └─0 paragraph[1]
+        └─0 image
+              title: null
+              url: "./img.png"
+              alt: null
+    `,
+    `<figure><img src="./img.png" id="fig1"></figure>`,
+    {
+      captionlessImagePolicy: 'figure',
+      assignIdToFigcaption: true,
+    },
+  ),
+);
+
+test(
+  "captionlessImagePolicy: 'figure-with-figcaption' with imgFigcaptionOrder: figcaption-img",
+  buildProcessorTestingCode(
+    `![](./img.png)`,
+    stripIndent`
+    root[1]
+    └─0 paragraph[1]
+        └─0 image
+              title: null
+              url: "./img.png"
+              alt: null
+    `,
+    `<figure><figcaption aria-hidden="true"></figcaption><img src="./img.png"></figure>`,
+    {
+      captionlessImagePolicy: 'figure-with-figcaption',
+      imgFigcaptionOrder: 'figcaption-img',
+    },
+  ),
+);
+
+test(
+  "captionlessImagePolicy: 'figure-with-figcaption' with assignIdToFigcaption moves ID to empty figcaption",
+  buildProcessorTestingCode(
+    `![](./img.png){#fig1}`,
+    stripIndent`
+    root[1]
+    └─0 paragraph[1]
+        └─0 image
+              title: null
+              url: "./img.png"
+              alt: null
+    `,
+    `<figure><img src="./img.png"><figcaption aria-hidden="true" id="fig1"></figcaption></figure>`,
+    {
+      captionlessImagePolicy: 'figure-with-figcaption',
+      assignIdToFigcaption: true,
+    },
+  ),
+);
+
+test(
+  "captionlessImagePolicy: 'figure-with-figcaption' does not affect captioned image",
+  buildProcessorTestingCode(
+    `![caption](./img.png)`,
+    stripIndent`
+    root[1]
+    └─0 paragraph[1]
+        └─0 image
+              title: null
+              url: "./img.png"
+              alt: "caption"
+    `,
+    `<figure><img src="./img.png" alt="caption"><figcaption aria-hidden="true">caption</figcaption></figure>`,
+    { captionlessImagePolicy: 'figure-with-figcaption' },
+  ),
+);
+
+test(
   'Only single line',
   buildProcessorTestingCode(
     stripIndent`

--- a/packages/vfm/tests/metadata.test.ts
+++ b/packages/vfm/tests/metadata.test.ts
@@ -133,6 +133,28 @@ other-meta2: 'other2'
   expect(received).toStrictEqual(expected);
 });
 
+test.each(['paragraph', 'figure', 'figure-with-figcaption'] as const)(
+  'captionlessImagePolicy: accepts %s',
+  (value) => {
+    const received = readMetadata(
+      `---\nvfm:\n  captionlessImagePolicy: ${value}\n---\n`,
+    );
+    expect(received.vfm?.captionlessImagePolicy).toBe(value);
+  },
+);
+
+test.each([
+  ['unknown string', 'inline'],
+  ['boolean', true],
+  ['number', 1],
+  ['null', null],
+])('captionlessImagePolicy: %s falls back to undefined', (_label, value) => {
+  const received = readMetadata(
+    `---\nvfm:\n  captionlessImagePolicy: ${JSON.stringify(value)}\n---\n`,
+  );
+  expect(received.vfm?.captionlessImagePolicy).toBeUndefined();
+});
+
 test('Title from heading', () => {
   const received = readMetadata(
     `# Heading Title with {Ruby|ルビ} and <mark>HTML tag</mark>`,

--- a/packages/vfm/tests/metadata.test.ts
+++ b/packages/vfm/tests/metadata.test.ts
@@ -125,6 +125,7 @@ other-meta2: 'other2'
       toc: false,
       theme: 'theme.css',
       assignIdToFigcaption: false,
+      captionlessImagePolicy: undefined,
       footnote: undefined,
     },
   };


### PR DESCRIPTION
#241 から伸ばしているブランチです。先に241をご確認ください。このブランチの変更は 440535f2f7819b8ffc462681a3d5385bea73fcf0 以降です。

新たなオプション`captionlessImagePolicy: 'paragraph' | 'figure' | 'figure-with-figcaption'`を追加するPRです。現在の挙動では、`![caption](./image.png)`のみのパラグラフは`<figure><figcaption><img></figcaption>`に変換されるものの、`![](./image.png)`（キャプションなし）のみのパラグラフは通常のCommonMarkの結果通り`<p><img></p>`を出力しています。このためキャプションあり/なしが混在している原稿では、`figure:has(img)`と`p:has(img)`のスタイルを合わせるか、figureに変換するプラグインを作成する必要がありました。

このオプションでは、キャプションなし画像のみのパラグラフの出力を、従来のp（デフォルト）、figcaptionなしfigure出力、空のfigcaptionありfigure出力で選べるようになっています。生成されたfigcaptionは`assignIdToFigcaption`・`imgFigcaptionOrder`にも反応します。