### PR TITLE
chore: add changeset to republish with CI-built artifacts

### DIFF
--- a/.changeset/slimy-frogs-vanish.md
+++ b/.changeset/slimy-frogs-vanish.md
@@ -1,0 +1,11 @@
+---
+'@vivliostyle/remark-footnote-dpub': patch
+'@vivliostyle/remark-footnote-gcpm': patch
+'@vivliostyle/remark-footnote-pandoc': patch
+'@vivliostyle/remark-ruby': patch
+'@vivliostyle/remark-sectionize': patch
+'@vivliostyle/vfm': patch
+'@vivliostyle/vfm-internal-utils': patch
+---
+
+Republish with build artifacts generated in CI


### PR DESCRIPTION
すべてのパッケージのリリースを再発火させるためのchangesetを追加するPRです。このPRをマージすると再度「Version Packages」PRが自動作成され、それをマージすると今度は自動リリースが成功するはずです。

---

Version Packages [#1](https://github.com/vivliostyle/vfm/actions/runs/29251114462/attempts/1), [#2](https://github.com/vivliostyle/vfm/actions/runs/29251114462/attempts/2)の失敗の原因は[Trusted publishing](https://docs.npmjs.com/trusted-publishers)が未設定だったことでした。パッケージの初回リリース時は[azu/setup-npm-trusted-publish](https://github.com/azu/setup-npm-trusted-publish)や手動で空のリリースを一回作成したあと、npmのパッケージページで`Settings > Trusted Publisher > GitHub Actions`を以下のように設定したうえでChangesetsによるリリースを発火させます。

```
Organization or user: vivliostyle
Repository: vfm
Workflow filename: release.yml
Environment name:
Allowed actions:
  - [x] Allow npm publish
  - [x] Allow npm stage publish  ... 現状不要かも
```

今回の失敗分については、Changesetsが行うはずだった作業を以下の通りロールフォワードしました。

<figure>
<figcaption>手動でタグの打ち直し</figcaption>

```bash
C=4c0ce59e86ee989e25111957c1ec882b2c179845
PKGS="vfm vfm-internal-utils remark-footnote-dpub remark-footnote-gcpm remark-footnote-pandoc remark-ruby remark-sectionize"
mkdir -p ../notes

for d in $PKGS; do
  name=$(node -p "require('./packages/$d/package.json').name")
  ver=$(node -p "require('./packages/$d/package.json').version")
  tag="$name@$ver"
  git tag "$tag" -m "$tag" "$C"

  # version と一致する見出しから同じ深さの次の見出しまで
  awk -v v="## $ver" '$0==v{f=1;next} /^## /{f=0} f' "packages/$d/CHANGELOG.md" > "../notes/$d.md"
done

git push origin \
  "refs/tags/@vivliostyle/vfm@2.7.1" \
  "refs/tags/@vivliostyle/vfm-internal-utils@1.0.0" \
  "refs/tags/@vivliostyle/remark-footnote-dpub@1.0.0" \
  "refs/tags/@vivliostyle/remark-footnote-gcpm@1.0.0" \
  "refs/tags/@vivliostyle/remark-footnote-pandoc@1.0.0" \
  "refs/tags/@vivliostyle/remark-ruby@1.0.0" \
  "refs/tags/@vivliostyle/remark-sectionize@1.0.0"
```

</figure>
<figure>
<figcaption>手動でリリース作成</figcaption>

```bash
for d in $PKGS; do
  name=$(node -p "require('./packages/$d/package.json').name")
  ver=$(node -p "require('./packages/$d/package.json').version")
  tag="$name@$ver"
  gh release create "$tag" -R vivliostyle/vfm --verify-tag --title "$tag" --notes-file "../notes/$d.md"
done

# Latestがremark-sectionizeになってしまったので
gh release edit "@vivliostyle/vfm@2.7.1" -R vivliostyle/vfm --latest
```

</figure>

加えて、Trusted publishingが正しく構成されていることを確認するために、一時ブランチを作成し、失敗時の[404を引き起こしていたPOST](https://github.com/pnpm/pnpm/blob/v11.2.2/releasing/commands/src/publish/oidc/authToken.ts)だけを再試行しました。201になっていることを確認できています。 https://github.com/vivliostyle/vfm/actions/runs/29336198251/workflow
